### PR TITLE
Handle insecure context for camera APIs gracefully

### DIFF
--- a/src/services/CameraService.ts
+++ b/src/services/CameraService.ts
@@ -1,4 +1,11 @@
+export function isSecureContext(): boolean {
+	return typeof navigator !== "undefined" && !!navigator.mediaDevices;
+}
+
 export async function getVideoDevices(): Promise<MediaDeviceInfo[]> {
+	if (!isSecureContext()) {
+		return [];
+	}
 	try {
 		const devices = await navigator.mediaDevices.enumerateDevices();
 		return devices.filter((device) => device.kind === "videoinput");
@@ -8,7 +15,20 @@ export async function getVideoDevices(): Promise<MediaDeviceInfo[]> {
 	}
 }
 
+export class InsecureContextError extends Error {
+	constructor() {
+		super(
+			"Camera requires HTTPS. Access this page via localhost or a secure connection.",
+		);
+		this.name = "InsecureContextError";
+	}
+}
+
 export async function start(deviceId?: string): Promise<MediaStream> {
+	if (!isSecureContext()) {
+		throw new InsecureContextError();
+	}
+
 	const constraints: MediaStreamConstraints = {
 		video: {
 			width: { ideal: 1920 },


### PR DESCRIPTION
## Summary
- Add `isSecureContext()` check for `navigator.mediaDevices` availability
- Add `InsecureContextError` with helpful message about HTTPS requirement
- Guard `useCamera` hook against missing `mediaDevices` (prevents crash on insecure context)
- Show specific error message when accessed over HTTP on non-localhost

Camera APIs require a secure context (HTTPS or localhost). This prevents crashes and shows a helpful error instead.

## Test plan
- [ ] Access app over HTTP (non-localhost) - should show error message instead of crashing
- [ ] Access app over HTTPS or localhost - should work normally
- [ ] Verify camera functionality still works in secure context

🤖 Generated with [Claude Code](https://claude.com/claude-code)