### PR TITLE
Add resolution selector with portrait/landscape toggle and per-camera settings

### DIFF
--- a/src/components/CameraStage.tsx
+++ b/src/components/CameraStage.tsx
@@ -206,8 +206,18 @@ export function CameraStage() {
 	});
 
 	// Camera State via Humble Object Hook
-	const { stream, error, devices, selectedDeviceId, setSelectedDeviceId, retry } =
-		useCamera();
+	const {
+		stream,
+		error,
+		devices,
+		selectedDeviceId,
+		setSelectedDeviceId,
+		resolution,
+		setResolution,
+		orientation,
+		setOrientation,
+		retry,
+	} = useCamera();
 
 	// Version check for updates
 	const {
@@ -452,6 +462,10 @@ export function CameraStage() {
 				devices={devices}
 				selectedDeviceId={selectedDeviceId}
 				onDeviceChange={setSelectedDeviceId}
+				resolution={resolution}
+				onResolutionChange={setResolution}
+				orientation={orientation}
+				onOrientationChange={setOrientation}
 				videoWidth={videoDimensions?.width}
 				videoHeight={videoDimensions?.height}
 				isMirror={isMirror}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink, Github, Smartphone } from "lucide-react";
+import { RESOLUTION_PRESETS, type Orientation, type Resolution } from "../services/CameraService";
 import {
 	SMOOTHING_PRESET_DESCRIPTIONS,
 	SMOOTHING_PRESET_LABELS,
@@ -14,6 +15,10 @@ interface SettingsModalProps {
 	devices: MediaDeviceInfo[];
 	selectedDeviceId: string;
 	onDeviceChange: (deviceId: string) => void;
+	resolution: Resolution;
+	onResolutionChange: (resolution: Resolution) => void;
+	orientation: Orientation;
+	onOrientationChange: (orientation: Orientation) => void;
 	videoWidth?: number;
 	videoHeight?: number;
 
@@ -61,6 +66,10 @@ export function SettingsModal({
 	devices,
 	selectedDeviceId,
 	onDeviceChange,
+	resolution,
+	onResolutionChange,
+	orientation,
+	onOrientationChange,
 	videoWidth,
 	videoHeight,
 	isMirror,
@@ -140,9 +149,59 @@ export function SettingsModal({
 								</option>
 							))}
 						</select>
+					</div>
+
+					{/* Resolution */}
+					<div className="space-y-2">
+						<label
+							htmlFor="resolution"
+							className="text-sm font-medium text-gray-400"
+						>
+							Resolution
+						</label>
+						<div className="flex gap-2">
+							<select
+								id="resolution"
+								value={resolution}
+								onChange={(e) => onResolutionChange(e.target.value as Resolution)}
+								className="flex-1 bg-black/30 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
+							>
+								{(Object.keys(RESOLUTION_PRESETS) as Resolution[]).map((res) => (
+									<option key={res} value={res}>
+										{RESOLUTION_PRESETS[res].label}
+									</option>
+								))}
+							</select>
+							<div className="flex rounded-lg overflow-hidden border border-white/10">
+								<button
+									type="button"
+									onClick={() => onOrientationChange("landscape")}
+									className={`px-3 py-2 text-sm font-medium transition-colors ${
+										orientation === "landscape"
+											? "bg-blue-600 text-white"
+											: "bg-black/30 text-gray-400 hover:text-white"
+									}`}
+									title="Landscape"
+								>
+									⬜
+								</button>
+								<button
+									type="button"
+									onClick={() => onOrientationChange("portrait")}
+									className={`px-3 py-2 text-sm font-medium transition-colors ${
+										orientation === "portrait"
+											? "bg-blue-600 text-white"
+											: "bg-black/30 text-gray-400 hover:text-white"
+									}`}
+									title="Portrait"
+								>
+									▯
+								</button>
+							</div>
+						</div>
 						{videoWidth && videoHeight && (
 							<div className="text-xs text-gray-500">
-								{videoWidth}×{videoHeight} ({(videoWidth / videoHeight).toFixed(2)} aspect ratio)
+								Actual: {videoWidth}×{videoHeight}
 							</div>
 						)}
 					</div>

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as CameraService from "../services/CameraService";
-import { InsecureContextError } from "../services/CameraService";
+import { InsecureContextError, type Orientation, type Resolution } from "../services/CameraService";
+import * as CameraSettingsService from "../services/CameraSettingsService";
 import { DeviceService } from "../services/DeviceService";
 
-const STORAGE_KEY = "magic-monitor-camera-device-id";
+const DEVICE_ID_STORAGE_KEY = "magic-monitor-camera-device-id";
 
 export function useCamera(initialDeviceId?: string) {
 	const [stream, setStream] = useState<MediaStream | null>(null);
@@ -11,17 +12,35 @@ export function useCamera(initialDeviceId?: string) {
 	const [error, setError] = useState<string | null>(null);
 	const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
 	const [selectedDeviceId, setSelectedDeviceId] = useState<string>(
-		initialDeviceId || DeviceService.getStorageItem(STORAGE_KEY) || "",
+		initialDeviceId || DeviceService.getStorageItem(DEVICE_ID_STORAGE_KEY) || "",
 	);
+
+	// Load settings for currently selected device
+	const [resolution, setResolution] = useState<Resolution>(() => {
+		const deviceId = initialDeviceId || DeviceService.getStorageItem(DEVICE_ID_STORAGE_KEY) || "";
+		return CameraSettingsService.getSettingsForDevice(deviceId).resolution;
+	});
+	const [orientation, setOrientation] = useState<Orientation>(() => {
+		const deviceId = initialDeviceId || DeviceService.getStorageItem(DEVICE_ID_STORAGE_KEY) || "";
+		return CameraSettingsService.getSettingsForDevice(deviceId).orientation;
+	});
+
 	const [retryCount, setRetryCount] = useState(0);
 
 	const getDevices = useCallback(async () => {
 		const videoDevices = await CameraService.getVideoDevices();
 		setDevices(videoDevices);
 
-		// If we have devices but none selected, pick the first one
+		// If we have devices but none selected, pick the first one and load its settings
 		if (videoDevices.length > 0 && !selectedDeviceId) {
-			setSelectedDeviceId(videoDevices[0].deviceId);
+			const deviceId = videoDevices[0].deviceId;
+			setSelectedDeviceId(deviceId);
+			DeviceService.setStorageItem(DEVICE_ID_STORAGE_KEY, deviceId);
+
+			// Load settings for the auto-selected device
+			const settings = CameraSettingsService.getSettingsForDevice(deviceId);
+			setResolution(settings.resolution);
+			setOrientation(settings.orientation);
 		}
 	}, [selectedDeviceId]);
 
@@ -61,6 +80,8 @@ export function useCamera(initialDeviceId?: string) {
 
 				const newStream = await CameraService.start(
 					selectedDeviceId || undefined,
+					resolution,
+					orientation,
 				);
 
 				if (!isActive) {
@@ -82,7 +103,7 @@ export function useCamera(initialDeviceId?: string) {
 						const settings = videoTrack.getSettings();
 						if (settings.deviceId) {
 							setSelectedDeviceId(settings.deviceId);
-							DeviceService.setStorageItem(STORAGE_KEY, settings.deviceId);
+							DeviceService.setStorageItem(DEVICE_ID_STORAGE_KEY, settings.deviceId);
 						}
 					}
 				}
@@ -108,13 +129,36 @@ export function useCamera(initialDeviceId?: string) {
 				streamRef.current = null;
 			}
 		};
-	}, [selectedDeviceId, getDevices, retryCount]); // Re-run when selected device changes or retry is triggered
+	}, [selectedDeviceId, resolution, orientation, getDevices, retryCount]); // Re-run when device/resolution/orientation changes
 
-	// Wrap setter to persist selection
+	// Wrap setter to persist selection and load device-specific settings
 	const handleSetSelectedDeviceId = useCallback((deviceId: string) => {
 		setSelectedDeviceId(deviceId);
-		DeviceService.setStorageItem(STORAGE_KEY, deviceId);
+		DeviceService.setStorageItem(DEVICE_ID_STORAGE_KEY, deviceId);
+
+		// Load settings for the new device
+		const settings = CameraSettingsService.getSettingsForDevice(deviceId);
+		setResolution(settings.resolution);
+		setOrientation(settings.orientation);
 	}, []);
+
+	// Wrap resolution setter to persist per-device
+	const handleSetResolution = useCallback(
+		(res: Resolution) => {
+			setResolution(res);
+			CameraSettingsService.updateSettingForDevice(selectedDeviceId, "resolution", res);
+		},
+		[selectedDeviceId],
+	);
+
+	// Wrap orientation setter to persist per-device
+	const handleSetOrientation = useCallback(
+		(orient: Orientation) => {
+			setOrientation(orient);
+			CameraSettingsService.updateSettingForDevice(selectedDeviceId, "orientation", orient);
+		},
+		[selectedDeviceId],
+	);
 
 	// Retry camera access - triggers re-run of the setup effect
 	const retry = useCallback(() => {
@@ -128,6 +172,10 @@ export function useCamera(initialDeviceId?: string) {
 		devices,
 		selectedDeviceId,
 		setSelectedDeviceId: handleSetSelectedDeviceId,
+		resolution,
+		setResolution: handleSetResolution,
+		orientation,
+		setOrientation: handleSetOrientation,
 		retry,
 	};
 }

--- a/src/services/CameraService.ts
+++ b/src/services/CameraService.ts
@@ -1,3 +1,17 @@
+export type Resolution = "720p" | "1080p" | "4k";
+export type Orientation = "landscape" | "portrait";
+
+export const RESOLUTION_PRESETS: Record<Resolution, { width: number; height: number; label: string }> = {
+	"720p": { width: 1280, height: 720, label: "720p (HD)" },
+	"1080p": { width: 1920, height: 1080, label: "1080p (Full HD)" },
+	"4k": { width: 3840, height: 2160, label: "4K (Ultra HD)" },
+};
+
+export interface CameraSettings {
+	resolution: Resolution;
+	orientation: Orientation;
+}
+
 export function isSecureContext(): boolean {
 	return typeof navigator !== "undefined" && !!navigator.mediaDevices;
 }
@@ -24,15 +38,24 @@ export class InsecureContextError extends Error {
 	}
 }
 
-export async function start(deviceId?: string): Promise<MediaStream> {
+export async function start(
+	deviceId?: string,
+	resolution: Resolution = "4k",
+	orientation: Orientation = "landscape",
+): Promise<MediaStream> {
 	if (!isSecureContext()) {
 		throw new InsecureContextError();
 	}
 
+	const preset = RESOLUTION_PRESETS[resolution];
+	// Swap width/height for portrait orientation
+	const width = orientation === "portrait" ? preset.height : preset.width;
+	const height = orientation === "portrait" ? preset.width : preset.height;
+
 	const constraints: MediaStreamConstraints = {
 		video: {
-			width: { ideal: 3840 },
-			height: { ideal: 2160 },
+			width: { ideal: width },
+			height: { ideal: height },
 			frameRate: { ideal: 30 },
 			deviceId: deviceId ? { exact: deviceId } : undefined,
 		},

--- a/src/services/CameraSettingsService.ts
+++ b/src/services/CameraSettingsService.ts
@@ -1,0 +1,86 @@
+import type { CameraSettings, Orientation, Resolution } from "./CameraService";
+import { DeviceService } from "./DeviceService";
+
+const DEVICE_SETTINGS_STORAGE_KEY = "magic-monitor-camera-device-settings";
+
+const DEFAULT_SETTINGS: CameraSettings = {
+	resolution: "4k",
+	orientation: "landscape",
+};
+
+/**
+ * Get settings for a specific camera device from localStorage.
+ * Returns default settings if none are stored for this device.
+ */
+export function getSettingsForDevice(deviceId: string): CameraSettings {
+	if (!deviceId) return DEFAULT_SETTINGS;
+
+	const stored = DeviceService.getStorageItem(DEVICE_SETTINGS_STORAGE_KEY);
+	if (stored) {
+		try {
+			const allSettings = JSON.parse(stored) as Record<string, CameraSettings>;
+			if (allSettings[deviceId]) {
+				return { ...DEFAULT_SETTINGS, ...allSettings[deviceId] };
+			}
+		} catch {
+			// Invalid JSON, return defaults
+		}
+	}
+	return DEFAULT_SETTINGS;
+}
+
+/**
+ * Save settings for a specific camera device to localStorage.
+ */
+export function saveSettingsForDevice(deviceId: string, settings: CameraSettings): void {
+	if (!deviceId) return;
+
+	const stored = DeviceService.getStorageItem(DEVICE_SETTINGS_STORAGE_KEY);
+	let allSettings: Record<string, CameraSettings> = {};
+	if (stored) {
+		try {
+			allSettings = JSON.parse(stored);
+		} catch {
+			// Invalid JSON, start fresh
+		}
+	}
+	allSettings[deviceId] = settings;
+	DeviceService.setStorageItem(DEVICE_SETTINGS_STORAGE_KEY, JSON.stringify(allSettings));
+}
+
+/**
+ * Update a single setting for a device (resolution or orientation).
+ */
+export function updateSettingForDevice(
+	deviceId: string,
+	key: "resolution",
+	value: Resolution,
+): void;
+export function updateSettingForDevice(
+	deviceId: string,
+	key: "orientation",
+	value: Orientation,
+): void;
+export function updateSettingForDevice(
+	deviceId: string,
+	key: keyof CameraSettings,
+	value: Resolution | Orientation,
+): void {
+	const current = getSettingsForDevice(deviceId);
+	saveSettingsForDevice(deviceId, { ...current, [key]: value });
+}
+
+/**
+ * Get all stored device settings (for debugging/export).
+ */
+export function getAllDeviceSettings(): Record<string, CameraSettings> {
+	const stored = DeviceService.getStorageItem(DEVICE_SETTINGS_STORAGE_KEY);
+	if (stored) {
+		try {
+			return JSON.parse(stored);
+		} catch {
+			return {};
+		}
+	}
+	return {};
+}

--- a/tests/magic-monitor.spec.ts
+++ b/tests/magic-monitor.spec.ts
@@ -398,6 +398,119 @@ test.describe("Magic Monitor E2E", () => {
 		const video = page.getByTestId("main-video");
 		await expect(video).toBeVisible();
 	});
+
+	test("Settings: Resolution selector shows options", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+
+		// Check resolution select is visible
+		const resolutionSelect = page.locator("select#resolution");
+		await expect(resolutionSelect).toBeVisible();
+
+		// Verify all resolution options are present
+		await expect(resolutionSelect).toContainText("720p (HD)");
+		await expect(resolutionSelect).toContainText("1080p (Full HD)");
+		await expect(resolutionSelect).toContainText("4K (Ultra HD)");
+	});
+
+	test("Settings: Resolution selector defaults to 4K", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+
+		// Check resolution select default value is 4k
+		const resolutionSelect = page.locator("select#resolution");
+		const value = await resolutionSelect.inputValue();
+		expect(value).toBe("4k");
+	});
+
+	test("Settings: Resolution change persists to localStorage (per-device)", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+
+		// Change resolution to 1080p
+		const resolutionSelect = page.locator("select#resolution");
+		await resolutionSelect.selectOption("1080p");
+
+		// Verify selection changed
+		const newValue = await resolutionSelect.inputValue();
+		expect(newValue).toBe("1080p");
+
+		// Close settings
+		await page.keyboard.press("Escape");
+
+		// Verify localStorage was updated with per-device settings
+		const storedSettings = await page.evaluate(() => {
+			return localStorage.getItem("magic-monitor-camera-device-settings");
+		});
+		expect(storedSettings).toBeTruthy();
+		const parsedSettings = JSON.parse(storedSettings!);
+		// Check that some device has resolution 1080p
+		const hasCorrectResolution = Object.values(parsedSettings).some(
+			(s: unknown) => (s as { resolution: string }).resolution === "1080p"
+		);
+		expect(hasCorrectResolution).toBe(true);
+
+		// Persist the value before reload (since beforeEach clears it via addInitScript)
+		await page.addInitScript(() => {
+			// Set up per-device settings for mock camera
+			const settings = { "mock-camera-1": { resolution: "1080p", orientation: "landscape" } };
+			localStorage.setItem("magic-monitor-camera-device-settings", JSON.stringify(settings));
+			localStorage.setItem("magic-monitor-camera-device-id", "mock-camera-1");
+		});
+
+		// Reload page and verify setting persisted
+		await page.reload();
+		await page.getByTitle("Settings").click();
+
+		const resolutionSelectAfterReload = page.locator("select#resolution");
+		const valueAfterReload = await resolutionSelectAfterReload.inputValue();
+		expect(valueAfterReload).toBe("1080p");
+	});
+
+	test("Settings: Resolution shows actual video dimensions", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+
+		// Wait for actual resolution to be displayed (after video metadata loads)
+		// The mock canvas stream may report different dimensions depending on browser/timing
+		const actualResolutionText = page.getByText(/Actual: \d+×\d+/);
+		await expect(actualResolutionText).toBeVisible({ timeout: 5000 });
+
+		// Just verify the format is correct - actual dimensions vary in test environment
+		const text = await actualResolutionText.textContent();
+		expect(text).toMatch(/Actual: \d+×\d+/);
+	});
+
+	test("Settings: Orientation toggle switches between landscape and portrait", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+
+		// Find the orientation toggle buttons
+		const landscapeButton = page.getByTitle("Landscape");
+		const portraitButton = page.getByTitle("Portrait");
+
+		// Verify both buttons exist
+		await expect(landscapeButton).toBeVisible();
+		await expect(portraitButton).toBeVisible();
+
+		// Landscape should be active by default (has bg-blue-600 class)
+		await expect(landscapeButton).toHaveClass(/bg-blue-600/);
+		await expect(portraitButton).not.toHaveClass(/bg-blue-600/);
+
+		// Click portrait
+		await portraitButton.click();
+
+		// Portrait should now be active
+		await expect(portraitButton).toHaveClass(/bg-blue-600/);
+		await expect(landscapeButton).not.toHaveClass(/bg-blue-600/);
+
+		// Click landscape again
+		await landscapeButton.click();
+
+		// Landscape should be active again
+		await expect(landscapeButton).toHaveClass(/bg-blue-600/);
+		await expect(portraitButton).not.toHaveClass(/bg-blue-600/);
+	});
 });
 
 test.describe("Bug Report", () => {


### PR DESCRIPTION
## Summary
- Add resolution dropdown (720p, 1080p, 4K) to Settings modal
- Add portrait/landscape orientation toggle buttons next to resolution
- Store settings per-camera device ID so each camera remembers its own resolution/orientation preferences
- Show actual video dimensions below resolution selector
- Fix bug: auto-selected camera now properly loads its stored settings on first load

## Changes
- `src/services/CameraService.ts` - Added `Orientation` type, updated `start()` to swap width/height for portrait
- `src/services/CameraSettingsService.ts` - **NEW** - Handles per-device settings storage in localStorage
- `src/hooks/useCamera.ts` - Loads/saves settings per device ID, fixed auto-select bug
- `src/components/SettingsModal.tsx` - Added resolution dropdown and orientation toggle UI
- `src/components/CameraStage.tsx` - Wired new props through to SettingsModal

## Test plan
- [x] Build passes
- [x] 169 unit tests pass
- [x] 5 new E2E tests for resolution/orientation all pass
- [ ] Manual test: Change resolution, verify camera restarts with new resolution
- [ ] Manual test: Switch cameras, verify each remembers its own settings
- [ ] Manual test: Toggle portrait/landscape, verify dimensions swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resolution selector in Settings with three preset options (720p, 1080p, 4K)
  * Added orientation toggle between landscape and portrait modes
  * Settings now persist per device and restore on page reload
  * Real-time video dimension display in Settings panel

* **Tests**
  * Added comprehensive Settings UI tests for resolution selection, orientation toggling, and per-device persistence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->