### PR TITLE
Fix dropdown closing bug in Settings modal

### DIFF
--- a/src/components/CameraStage.tsx
+++ b/src/components/CameraStage.tsx
@@ -71,6 +71,11 @@ export function CameraStage() {
 	const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 	const [isAboutOpen, setIsAboutOpen] = useState(false);
 
+	// Stable callbacks for modal close handlers
+	// These must be stable to prevent useFocusTrap from re-running and stealing focus
+	const handleCloseSettings = useCallback(() => setIsSettingsOpen(false), []);
+	const handleCloseAbout = useCallback(() => setIsAboutOpen(false), []);
+
 	// Manual zoom/pan callback - disables smart zoom when user manually zooms
 	// Wrapped in useCallback to prevent effect re-runs in useZoomPan
 	const handleManualZoom = useCallback(() => {
@@ -357,7 +362,7 @@ export function CameraStage() {
 
 			<SettingsModal
 				isOpen={isSettingsOpen}
-				onClose={() => setIsSettingsOpen(false)}
+				onClose={handleCloseSettings}
 				devices={devices}
 				selectedDeviceId={selectedDeviceId}
 				onDeviceChange={setSelectedDeviceId}
@@ -396,7 +401,7 @@ export function CameraStage() {
 
 			<AboutModal
 				isOpen={isAboutOpen}
-				onClose={() => setIsAboutOpen(false)}
+				onClose={handleCloseAbout}
 				githubRepoUrl={bugReporter.githubRepoUrl}
 				onReportBug={bugReporter.open}
 				bugReportShortcut={bugReportShortcut}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1,0 +1,216 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingsModal } from "./SettingsModal";
+
+// Default props for testing
+function createDefaultProps(overrides: Partial<Parameters<typeof SettingsModal>[0]> = {}) {
+	return {
+		isOpen: true,
+		onClose: vi.fn(),
+		devices: [
+			{ deviceId: "device-1", kind: "videoinput" as const, label: "Camera 1", groupId: "group1", toJSON: () => ({}) },
+			{ deviceId: "device-2", kind: "videoinput" as const, label: "Camera 2", groupId: "group1", toJSON: () => ({}) },
+		],
+		selectedDeviceId: "device-1",
+		onDeviceChange: vi.fn(),
+		resolution: "4k" as const,
+		onResolutionChange: vi.fn(),
+		orientation: "landscape" as const,
+		onOrientationChange: vi.fn(),
+		videoWidth: 3840,
+		videoHeight: 2160,
+		isMirror: false,
+		onMirrorChange: vi.fn(),
+		isSmartZoom: false,
+		isModelLoading: false,
+		onSmartZoomChange: vi.fn(),
+		smoothingPreset: "ema" as const,
+		onSmoothingPresetChange: vi.fn(),
+		showHandSkeleton: false,
+		onShowHandSkeletonChange: vi.fn(),
+		flashEnabled: false,
+		onFlashEnabledChange: vi.fn(),
+		threshold: 25,
+		onThresholdChange: vi.fn(),
+		isPickingColor: false,
+		onPickColorClick: vi.fn(),
+		targetColor: null,
+		updateAvailable: false,
+		isCheckingUpdate: false,
+		lastCheckTime: null,
+		onCheckForUpdate: vi.fn(),
+		onReloadForUpdate: vi.fn(),
+		shakeEnabled: false,
+		onShakeEnabledChange: vi.fn(),
+		isShakeSupported: false,
+		onOpenAbout: vi.fn(),
+		...overrides,
+	};
+}
+
+describe("SettingsModal", () => {
+	describe("rendering", () => {
+		it("renders when isOpen is true", () => {
+			render(<SettingsModal {...createDefaultProps()} />);
+			expect(screen.getByText("Settings")).toBeInTheDocument();
+		});
+
+		it("does not render when isOpen is false", () => {
+			render(<SettingsModal {...createDefaultProps({ isOpen: false })} />);
+			expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("resolution dropdown", () => {
+		it("displays all resolution options", () => {
+			render(<SettingsModal {...createDefaultProps()} />);
+
+			const resolutionSelect = screen.getByLabelText("Resolution");
+			expect(resolutionSelect).toBeInTheDocument();
+
+			// Check all options are present
+			const options = resolutionSelect.querySelectorAll("option");
+			expect(options).toHaveLength(3);
+			expect(options[0]).toHaveTextContent("720p (HD)");
+			expect(options[1]).toHaveTextContent("1080p (Full HD)");
+			expect(options[2]).toHaveTextContent("4K (Ultra HD)");
+		});
+
+		it("shows current resolution as selected", () => {
+			render(<SettingsModal {...createDefaultProps({ resolution: "1080p" })} />);
+
+			const resolutionSelect = screen.getByLabelText("Resolution") as HTMLSelectElement;
+			expect(resolutionSelect.value).toBe("1080p");
+		});
+
+		it("calls onResolutionChange when resolution is changed", () => {
+			const onResolutionChange = vi.fn();
+			render(<SettingsModal {...createDefaultProps({ onResolutionChange })} />);
+
+			const resolutionSelect = screen.getByLabelText("Resolution");
+			fireEvent.change(resolutionSelect, { target: { value: "720p" } });
+
+			expect(onResolutionChange).toHaveBeenCalledWith("720p");
+		});
+
+		it("displays actual video dimensions when provided", () => {
+			render(<SettingsModal {...createDefaultProps({ videoWidth: 1920, videoHeight: 1080 })} />);
+
+			expect(screen.getByText("Actual: 1920×1080")).toBeInTheDocument();
+		});
+
+		it("does not display actual dimensions when not provided", () => {
+			render(<SettingsModal {...createDefaultProps({ videoWidth: undefined, videoHeight: undefined })} />);
+
+			expect(screen.queryByText(/Actual:/)).not.toBeInTheDocument();
+		});
+	});
+
+	describe("orientation toggle", () => {
+		it("shows landscape as active by default", () => {
+			render(<SettingsModal {...createDefaultProps({ orientation: "landscape" })} />);
+
+			const landscapeButton = screen.getByTitle("Landscape");
+			const portraitButton = screen.getByTitle("Portrait");
+
+			expect(landscapeButton).toHaveClass("bg-blue-600");
+			expect(portraitButton).not.toHaveClass("bg-blue-600");
+		});
+
+		it("shows portrait as active when orientation is portrait", () => {
+			render(<SettingsModal {...createDefaultProps({ orientation: "portrait" })} />);
+
+			const landscapeButton = screen.getByTitle("Landscape");
+			const portraitButton = screen.getByTitle("Portrait");
+
+			expect(landscapeButton).not.toHaveClass("bg-blue-600");
+			expect(portraitButton).toHaveClass("bg-blue-600");
+		});
+
+		it("calls onOrientationChange when portrait is clicked", () => {
+			const onOrientationChange = vi.fn();
+			render(<SettingsModal {...createDefaultProps({ onOrientationChange })} />);
+
+			fireEvent.click(screen.getByTitle("Portrait"));
+
+			expect(onOrientationChange).toHaveBeenCalledWith("portrait");
+		});
+
+		it("calls onOrientationChange when landscape is clicked", () => {
+			const onOrientationChange = vi.fn();
+			render(<SettingsModal {...createDefaultProps({ orientation: "portrait", onOrientationChange })} />);
+
+			fireEvent.click(screen.getByTitle("Landscape"));
+
+			expect(onOrientationChange).toHaveBeenCalledWith("landscape");
+		});
+	});
+
+	describe("camera source dropdown", () => {
+		it("displays all camera devices", () => {
+			render(<SettingsModal {...createDefaultProps()} />);
+
+			const cameraSelect = screen.getByLabelText("Camera Source");
+			const options = cameraSelect.querySelectorAll("option");
+
+			expect(options).toHaveLength(2);
+			expect(options[0]).toHaveTextContent("Camera 1");
+			expect(options[1]).toHaveTextContent("Camera 2");
+		});
+
+		it("shows current device as selected", () => {
+			render(<SettingsModal {...createDefaultProps({ selectedDeviceId: "device-2" })} />);
+
+			const cameraSelect = screen.getByLabelText("Camera Source") as HTMLSelectElement;
+			expect(cameraSelect.value).toBe("device-2");
+		});
+
+		it("calls onDeviceChange when device is changed", () => {
+			const onDeviceChange = vi.fn();
+			render(<SettingsModal {...createDefaultProps({ onDeviceChange })} />);
+
+			const cameraSelect = screen.getByLabelText("Camera Source");
+			fireEvent.change(cameraSelect, { target: { value: "device-2" } });
+
+			expect(onDeviceChange).toHaveBeenCalledWith("device-2");
+		});
+
+		it("uses fallback label when device has no label", () => {
+			const devicesWithoutLabels = [
+				{ deviceId: "device-1", kind: "videoinput" as const, label: "", groupId: "group1", toJSON: () => ({}) },
+				{ deviceId: "device-2", kind: "videoinput" as const, label: "", groupId: "group1", toJSON: () => ({}) },
+			];
+			render(<SettingsModal {...createDefaultProps({ devices: devicesWithoutLabels })} />);
+
+			const cameraSelect = screen.getByLabelText("Camera Source");
+			const options = cameraSelect.querySelectorAll("option");
+
+			expect(options[0]).toHaveTextContent("Camera 1");
+			expect(options[1]).toHaveTextContent("Camera 2");
+		});
+	});
+
+	describe("close button", () => {
+		it("calls onClose when close button is clicked", () => {
+			const onClose = vi.fn();
+			render(<SettingsModal {...createDefaultProps({ onClose })} />);
+
+			fireEvent.click(screen.getByLabelText("Close settings"));
+
+			expect(onClose).toHaveBeenCalled();
+		});
+
+		it("calls onClose when clicking outside modal", () => {
+			const onClose = vi.fn();
+			render(<SettingsModal {...createDefaultProps({ onClose })} />);
+
+			// Click on the backdrop (the outermost div)
+			const backdrop = screen.getByText("Settings").parentElement?.parentElement?.parentElement;
+			if (backdrop) {
+				fireEvent.click(backdrop);
+				expect(onClose).toHaveBeenCalled();
+			}
+		});
+	});
+});

--- a/tests/dropdown-bug.spec.ts
+++ b/tests/dropdown-bug.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+// Reusable mock injection function
+async function injectMockCamera(page: import("@playwright/test").Page) {
+	await page.addInitScript(() => {
+		const canvas = document.createElement("canvas");
+		canvas.width = 1920;
+		canvas.height = 1080;
+		const ctx = canvas.getContext("2d");
+		if (ctx) {
+			ctx.fillStyle = "#111";
+			ctx.fillRect(0, 0, 1920, 1080);
+		}
+
+		function createMockStream() {
+			return canvas.captureStream(30);
+		}
+
+		if (!navigator.mediaDevices) {
+			// @ts-expect-error - navigator.mediaDevices is read-only but we need to mock it
+			navigator.mediaDevices = {};
+		}
+
+		navigator.mediaDevices.getUserMedia = async () => createMockStream();
+		navigator.mediaDevices.enumerateDevices = async () =>
+			[
+				{
+					deviceId: "mock-camera-1",
+					kind: "videoinput",
+					label: "Mock Camera 1",
+					groupId: "group1",
+				},
+				{
+					deviceId: "mock-camera-2",
+					kind: "videoinput",
+					label: "Mock Camera 2",
+					groupId: "group1",
+				},
+			] as MediaDeviceInfo[];
+	});
+}
+
+test.describe("Dropdown Bug Investigation", () => {
+	test.beforeEach(async ({ page }) => {
+		await injectMockCamera(page);
+		await page.addInitScript(() => {
+			localStorage.clear();
+		});
+		await page.goto("/");
+	});
+
+	test("Resolution dropdown should stay open when clicked", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+		await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+		// Click on the resolution dropdown
+		const resolutionSelect = page.locator("select#resolution");
+		await expect(resolutionSelect).toBeVisible();
+
+		// Try to interact with the dropdown
+		await resolutionSelect.click();
+
+		// Wait a bit to see if modal closes
+		await page.waitForTimeout(300);
+
+		// The settings modal should still be visible
+		const settingsHeading = page.getByRole("heading", { name: "Settings" });
+		const isStillVisible = await settingsHeading.isVisible();
+
+		console.log("Settings modal visible after clicking dropdown:", isStillVisible);
+
+		// This should pass - dropdown click shouldn't close the modal
+		await expect(settingsHeading).toBeVisible();
+
+		// Now try selecting an option
+		await resolutionSelect.selectOption("1080p");
+
+		// Modal should still be visible after selection
+		await expect(settingsHeading).toBeVisible();
+
+		// Verify selection changed
+		const value = await resolutionSelect.inputValue();
+		expect(value).toBe("1080p");
+	});
+
+	test("Camera source dropdown should stay open when clicked", async ({ page }) => {
+		// Open settings
+		await page.getByTitle("Settings").click();
+		await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+		// Click on the camera source dropdown
+		const cameraSelect = page.locator("select#camera-source");
+		await expect(cameraSelect).toBeVisible();
+
+		// Try to interact with the dropdown
+		await cameraSelect.click();
+
+		// Wait a bit to see if modal closes
+		await page.waitForTimeout(300);
+
+		// The settings modal should still be visible
+		const settingsHeading = page.getByRole("heading", { name: "Settings" });
+		await expect(settingsHeading).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary
- Fix bug where Resolution and Camera Source dropdowns instantly closed when clicked
- Root cause: inline `onClose` arrow functions caused `useFocusTrap` to re-run and steal focus
- Solution: wrap close handlers in `useCallback` for stable references

## Test plan
- [x] Open Settings → click Resolution dropdown → verify it stays open
- [x] Open Settings → click Camera Source dropdown → verify it stays open
- [x] All 495 unit tests pass
- [x] E2E tests for dropdown behavior pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for SettingsModal component covering rendering, dropdown interactions, and modal close behavior.
  * Added resolution and orientation handling tests for useCamera hook.
  * Added end-to-end tests verifying dropdown interactions within Settings modal.

* **Refactor**
  * Optimized modal close callbacks for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->