### PR TITLE
Add singleton service for HandLandmarker model

### DIFF
--- a/src/hooks/useSmartZoom.test.ts
+++ b/src/hooks/useSmartZoom.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HandLandmarkerService } from "../services/HandLandmarkerService";
 import {
 	clampNormalizedPan,
 	clampPanToViewport,
@@ -38,6 +39,9 @@ describe("useSmartZoom", () => {
 
 	beforeEach(() => {
 		vi.useFakeTimers();
+
+		// Reset the singleton service before each test
+		HandLandmarkerService._reset();
 
 		// Mock fetch for model loading
 		globalThis.fetch = vi.fn().mockResolvedValue({

--- a/src/services/HandLandmarkerService.test.ts
+++ b/src/services/HandLandmarkerService.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock functions must be defined inside the mock factory to avoid hoisting issues
+vi.mock("@mediapipe/tasks-vision", () => {
+	const mockDetectForVideo = vi.fn();
+	const mockClose = vi.fn();
+	return {
+		FilesetResolver: {
+			forVisionTasks: vi.fn().mockResolvedValue("mock-vision-source"),
+		},
+		HandLandmarker: {
+			createFromOptions: vi.fn().mockResolvedValue({
+				detectForVideo: mockDetectForVideo,
+				close: mockClose,
+			}),
+		},
+		// Export for test access
+		__mockClose: mockClose,
+		__mockDetectForVideo: mockDetectForVideo,
+	};
+});
+
+// Import after mock setup
+import { HandLandmarkerService } from "./HandLandmarkerService";
+import { __mockClose, __mockDetectForVideo } from "@mediapipe/tasks-vision";
+
+describe("HandLandmarkerService", () => {
+	beforeEach(() => {
+		HandLandmarkerService._reset();
+
+		// Mock fetch for model loading
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			headers: {
+				get: vi.fn().mockReturnValue("8192"),
+			},
+			body: {
+				getReader: vi.fn().mockReturnValue({
+					read: vi
+						.fn()
+						.mockResolvedValueOnce({
+							done: false,
+							value: new Uint8Array(1024),
+						})
+						.mockResolvedValueOnce({ done: true }),
+				}),
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should start in idle state", () => {
+		const state = HandLandmarkerService.getState();
+		expect(state.phase).toBe("idle");
+		expect(state.progress).toBe(0);
+	});
+
+	it("should load model and transition to ready", async () => {
+		const states: string[] = [];
+		HandLandmarkerService.subscribe((state) => {
+			states.push(state.phase);
+		});
+
+		await HandLandmarkerService.load();
+
+		expect(states).toContain("downloading");
+		expect(states).toContain("initializing");
+		expect(states).toContain("ready");
+		expect(HandLandmarkerService.isReady()).toBe(true);
+	});
+
+	it("should return same model on subsequent load calls", async () => {
+		const model1 = await HandLandmarkerService.load();
+		const model2 = await HandLandmarkerService.load();
+
+		expect(model1).toBe(model2);
+		// fetch should only be called once
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("should only load once even with concurrent calls", async () => {
+		// Start two loads in parallel
+		const promise1 = HandLandmarkerService.load();
+		const promise2 = HandLandmarkerService.load();
+
+		const [model1, model2] = await Promise.all([promise1, promise2]);
+
+		// Both should return the same model
+		expect(model1).toBe(model2);
+		// Fetch should only be called once
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("should notify all subscribers of state changes", async () => {
+		const listener1States: string[] = [];
+		const listener2States: string[] = [];
+
+		HandLandmarkerService.subscribe((state) => listener1States.push(state.phase));
+		HandLandmarkerService.subscribe((state) => listener2States.push(state.phase));
+
+		await HandLandmarkerService.load();
+
+		expect(listener1States).toEqual(listener2States);
+		expect(listener1States.length).toBeGreaterThan(1);
+	});
+
+	it("should allow unsubscribing", async () => {
+		const states: string[] = [];
+		const unsubscribe = HandLandmarkerService.subscribe((state) => {
+			states.push(state.phase);
+		});
+
+		// Unsubscribe immediately after getting initial state
+		unsubscribe();
+		const countAfterUnsubscribe = states.length;
+
+		await HandLandmarkerService.load();
+
+		// Should not have received any more updates
+		expect(states.length).toBe(countAfterUnsubscribe);
+	});
+
+	it("should track download progress", async () => {
+		let maxProgress = 0;
+		HandLandmarkerService.subscribe((state) => {
+			if (state.progress > maxProgress) {
+				maxProgress = state.progress;
+			}
+		});
+
+		await HandLandmarkerService.load();
+
+		expect(maxProgress).toBeGreaterThan(0);
+	});
+
+	it("should close model on reset", async () => {
+		await HandLandmarkerService.load();
+		expect(HandLandmarkerService.isReady()).toBe(true);
+
+		HandLandmarkerService._reset();
+
+		expect(__mockClose).toHaveBeenCalled();
+		expect(HandLandmarkerService.isReady()).toBe(false);
+		expect(HandLandmarkerService.getModel()).toBeNull();
+	});
+
+	it("should handle fetch error gracefully", async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+		const result = await HandLandmarkerService.load();
+
+		expect(result).toBeNull();
+		expect(HandLandmarkerService.getState().phase).toBe("error");
+		expect(HandLandmarkerService.isReady()).toBe(false);
+	});
+
+	it("should allow retry after error", async () => {
+		// First call fails
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+		await HandLandmarkerService.load();
+		expect(HandLandmarkerService.getState().phase).toBe("error");
+
+		// Reset fetch mock to succeed
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			headers: { get: vi.fn().mockReturnValue("8192") },
+			body: {
+				getReader: vi.fn().mockReturnValue({
+					read: vi
+						.fn()
+						.mockResolvedValueOnce({ done: false, value: new Uint8Array(1024) })
+						.mockResolvedValueOnce({ done: true }),
+				}),
+			},
+		});
+
+		// Retry should work
+		await HandLandmarkerService.load();
+		expect(HandLandmarkerService.isReady()).toBe(true);
+	});
+
+	it("getModel returns null before loading", () => {
+		expect(HandLandmarkerService.getModel()).toBeNull();
+	});
+
+	it("getModel returns model after loading", async () => {
+		await HandLandmarkerService.load();
+		const model = HandLandmarkerService.getModel();
+		expect(model).not.toBeNull();
+		expect(model?.detectForVideo).toBe(__mockDetectForVideo);
+	});
+
+	it("isLoading returns true during load", async () => {
+		expect(HandLandmarkerService.isLoading()).toBe(false);
+
+		const loadPromise = HandLandmarkerService.load();
+
+		// Can't easily test mid-load state synchronously, but we can verify it finishes
+		await loadPromise;
+		expect(HandLandmarkerService.isLoading()).toBe(false);
+	});
+});

--- a/src/services/HandLandmarkerService.ts
+++ b/src/services/HandLandmarkerService.ts
@@ -1,0 +1,187 @@
+/**
+ * Singleton service for MediaPipe HandLandmarker model.
+ *
+ * The model takes 3-5 seconds to download and initialize. This service
+ * ensures the model is loaded once and shared across all components
+ * (CameraStage, ReplayView) instead of reloading on every mount.
+ */
+import { FilesetResolver, HandLandmarker } from "@mediapipe/tasks-vision";
+
+export type LoadingPhase = "idle" | "downloading" | "initializing" | "ready" | "error";
+
+export interface LoadingState {
+	phase: LoadingPhase;
+	progress: number; // 0-100 for downloading phase
+	error?: Error;
+}
+
+type LoadingListener = (state: LoadingState) => void;
+
+class HandLandmarkerServiceImpl {
+	private model: HandLandmarker | null = null;
+	private loadingState: LoadingState = { phase: "idle", progress: 0 };
+	private loadPromise: Promise<HandLandmarker | null> | null = null;
+	private listeners: Set<LoadingListener> = new Set();
+
+	/**
+	 * Get the current loading state
+	 */
+	getState(): LoadingState {
+		return this.loadingState;
+	}
+
+	/**
+	 * Get the model if loaded, or null if not ready
+	 */
+	getModel(): HandLandmarker | null {
+		return this.model;
+	}
+
+	/**
+	 * Subscribe to loading state changes
+	 */
+	subscribe(listener: LoadingListener): () => void {
+		this.listeners.add(listener);
+		// Immediately notify with current state
+		listener(this.loadingState);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	private notifyListeners() {
+		for (const listener of this.listeners) {
+			listener(this.loadingState);
+		}
+	}
+
+	private updateState(state: Partial<LoadingState>) {
+		this.loadingState = { ...this.loadingState, ...state };
+		this.notifyListeners();
+	}
+
+	/**
+	 * Load the model if not already loaded/loading.
+	 * Returns a promise that resolves when the model is ready.
+	 * Safe to call multiple times - subsequent calls return the same promise.
+	 */
+	async load(): Promise<HandLandmarker | null> {
+		// Already loaded
+		if (this.model) {
+			return this.model;
+		}
+
+		// Already loading - return existing promise
+		if (this.loadPromise) {
+			return this.loadPromise;
+		}
+
+		// Start loading
+		this.loadPromise = this.loadModel();
+		return this.loadPromise;
+	}
+
+	private async loadModel(): Promise<HandLandmarker | null> {
+		try {
+			this.updateState({ phase: "downloading", progress: 0 });
+
+			// Use local WASM files for offline support
+			const vision = await FilesetResolver.forVisionTasks("/mediapipe/wasm");
+
+			// Fetch model with progress tracking
+			const response = await fetch("/mediapipe/hand_landmarker.task");
+			const contentLength = response.headers.get("Content-Length");
+			const total = contentLength ? parseInt(contentLength, 10) : 0;
+
+			if (!response.body) {
+				throw new Error("Response body is null");
+			}
+
+			const reader = response.body.getReader();
+			let receivedLength = 0;
+			const chunks: Uint8Array[] = [];
+
+			// Read chunks and track progress
+			while (true) {
+				const { done, value } = await reader.read();
+
+				if (done) break;
+
+				chunks.push(value);
+				receivedLength += value.length;
+
+				// Update progress (0-100%)
+				if (total > 0) {
+					this.updateState({ progress: Math.round((receivedLength / total) * 100) });
+				}
+			}
+
+			// Combine chunks into single Uint8Array
+			const modelBuffer = new Uint8Array(receivedLength);
+			let position = 0;
+			for (const chunk of chunks) {
+				modelBuffer.set(chunk, position);
+				position += chunk.length;
+			}
+
+			// Download complete, now initializing model
+			this.updateState({ phase: "initializing", progress: 100 });
+
+			// Create HandLandmarker with GPU delegate specified during creation
+			console.log("[HandLandmarkerService] Creating HandLandmarker with GPU delegate...");
+			this.model = await HandLandmarker.createFromOptions(vision, {
+				baseOptions: {
+					modelAssetBuffer: modelBuffer,
+					delegate: "GPU",
+				},
+				runningMode: "VIDEO",
+				numHands: 2,
+			});
+
+			// Log WebGL availability for GPU delegate diagnostics
+			const canvas = document.createElement("canvas");
+			const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+			console.log("[HandLandmarkerService] WebGL available:", !!gl, gl ? `(${gl.getParameter(gl.VERSION)})` : "");
+			console.log("[HandLandmarkerService] HandLandmarker initialized successfully");
+
+			this.updateState({ phase: "ready" });
+			return this.model;
+		} catch (error) {
+			console.error("[HandLandmarkerService] Error loading HandLandmarker:", error);
+			this.updateState({ phase: "error", error: error as Error });
+			this.loadPromise = null; // Allow retry
+			return null;
+		}
+	}
+
+	/**
+	 * Check if the model is ready for use
+	 */
+	isReady(): boolean {
+		return this.loadingState.phase === "ready" && this.model !== null;
+	}
+
+	/**
+	 * Check if the model is currently loading
+	 */
+	isLoading(): boolean {
+		return this.loadingState.phase === "downloading" || this.loadingState.phase === "initializing";
+	}
+
+	/**
+	 * Reset the service state (for testing only).
+	 * Closes any loaded model and resets to initial state.
+	 */
+	_reset(): void {
+		if (this.model) {
+			this.model.close();
+			this.model = null;
+		}
+		this.loadingState = { phase: "idle", progress: 0 };
+		this.loadPromise = null;
+		this.listeners.clear();
+	}
+}
+
+// Export singleton instance
+export const HandLandmarkerService = new HandLandmarkerServiceImpl();


### PR DESCRIPTION
## Summary
- Created `HandLandmarkerService` singleton to cache the MediaPipe HandLandmarker model
- Updated `useSmartZoom` to use the shared service instead of loading its own instance
- Model now loads once and is shared across CameraStage (live) and ReplayView (replay)

**Before:** Each view loaded its own model (~3-5 sec delay when switching to replay)  
**After:** Model loads once on first use, subsequent views get it instantly

## Test plan
- [x] Build passes
- [x] All unit tests pass
- [ ] Manual test: Enable smart zoom in live view, verify model loads once
- [ ] Manual test: Switch to replay with smart zoom enabled, verify no re-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)