### PR TITLE
Request only width from camera, let it pick native aspect ratio

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -72,9 +72,9 @@ describe("SettingsModal", () => {
 			// Check all options are present
 			const options = resolutionSelect.querySelectorAll("option");
 			expect(options).toHaveLength(3);
-			expect(options[0]).toHaveTextContent("720p (HD)");
-			expect(options[1]).toHaveTextContent("1080p (Full HD)");
-			expect(options[2]).toHaveTextContent("4K (Ultra HD)");
+			expect(options[0]).toHaveTextContent("1280 wide (720p)");
+			expect(options[1]).toHaveTextContent("1920 wide (1080p)");
+			expect(options[2]).toHaveTextContent("3840 wide (4k)");
 		});
 
 		it("shows current resolution as selected", () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -174,11 +174,14 @@ export function SettingsModal({
 								onChange={(e) => onResolutionChange(e.target.value as Resolution)}
 								className="flex-1 bg-black/30 border border-white/10 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
 							>
-								{(Object.keys(RESOLUTION_PRESETS) as Resolution[]).map((res) => (
+								{(Object.keys(RESOLUTION_PRESETS) as Resolution[]).map((res) => {
+								const preset = RESOLUTION_PRESETS[res];
+								return (
 									<option key={res} value={res}>
-										{RESOLUTION_PRESETS[res].label}
+										{preset.width} wide ({res})
 									</option>
-								))}
+								);
+							})}
 							</select>
 							<div className="flex rounded-lg overflow-hidden border border-white/10">
 								<button

--- a/src/services/CameraService.ts
+++ b/src/services/CameraService.ts
@@ -48,20 +48,19 @@ export async function start(
 	}
 
 	const preset = RESOLUTION_PRESETS[resolution];
-	// Swap width/height for portrait orientation
-	const width = orientation === "portrait" ? preset.height : preset.width;
-	const height = orientation === "portrait" ? preset.width : preset.height;
+	// Only request width - let camera use its native aspect ratio
+	const targetWidth = orientation === "portrait" ? preset.height : preset.width;
 
 	const constraints: MediaStreamConstraints = {
 		video: {
-			width: { ideal: width },
-			height: { ideal: height },
+			width: { ideal: targetWidth },
+			// No height constraint - camera picks based on native aspect ratio
 			frameRate: { ideal: 30 },
 			deviceId: deviceId ? { exact: deviceId } : undefined,
 		},
 	};
 
-	console.log("Requesting camera with constraints:", constraints);
+	console.log(`[Camera] Requesting width: ${targetWidth} (camera picks height)`);
 	return navigator.mediaDevices.getUserMedia(constraints);
 }
 


### PR DESCRIPTION
## Summary
- Remove height constraint from camera constraints - camera now uses its native aspect ratio
- Fixes aspect ratio issues on MacBooks with 4:3 cameras (was forcing 16:9)
- Update resolution dropdown to show width explicitly: "1280 wide (720p)"

## Test plan
- [ ] Open settings, verify dropdown shows "1280 wide (720p)", "1920 wide (1080p)", "3840 wide (4k)"
- [ ] Select different resolutions, verify "Actual: X×Y" shows camera's native aspect ratio
- [ ] Test on MacBook (4:3 camera) - should no longer force 16:9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated resolution display options to show width measurements (e.g., "1280 wide (720p)") instead of preset names for improved clarity.

* **Tests**
  * Updated test expectations for resolution display labels.

* **Refactor**
  * Optimized camera constraint handling to improve aspect ratio selection based on device orientation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->