### PR TITLE
Add error handling and logging for MediaRecorder detection

### DIFF
--- a/src/services/MediaRecorderService.ts
+++ b/src/services/MediaRecorderService.ts
@@ -60,6 +60,9 @@ export const MediaRecorderService = {
 				return "video/mp4";
 			}
 			// Let iOS pick - it will use MP4
+			console.warn(
+				"[MediaRecorder] No specific MP4 codec detected as supported on iOS, letting browser pick",
+			);
 			return "";
 		}
 
@@ -83,6 +86,9 @@ export const MediaRecorderService = {
 			return "video/mp4";
 		}
 		// Last resort - let browser pick
+		console.warn(
+			"[MediaRecorder] No supported codec detected, letting browser pick",
+		);
 		return "";
 	},
 

--- a/src/utils/bugReportFormatters.ts
+++ b/src/utils/bugReportFormatters.ts
@@ -127,29 +127,40 @@ export interface DeviceInfoGetters {
 
 /**
  * Collect MediaRecorder debug info for bug reports.
+ * Wrapped in try-catch to ensure bug reporting never fails due to detection errors.
  */
 export function getMediaRecorderInfo(): MediaRecorderInfo {
-	const available = typeof MediaRecorder !== "undefined";
-	const isIOSSafari = available ? MediaRecorderService.isIOSSafari() : false;
-	const selectedCodec = available ? MediaRecorderService.getBestCodec() : "";
+	try {
+		const available = typeof MediaRecorder !== "undefined";
+		const isIOSSafari = available ? MediaRecorderService.isIOSSafari() : false;
+		const selectedCodec = available ? MediaRecorderService.getBestCodec() : "";
 
-	// Test codecs
-	const codecsToTest = [
-		"video/webm;codecs=vp9",
-		"video/webm",
-		"video/mp4;codecs=avc1.42E01E",
-		"video/mp4",
-	];
-	const supportedCodecs = available
-		? codecsToTest.filter((codec) => MediaRecorderService.isTypeSupported(codec))
-		: [];
+		// Test codecs
+		const codecsToTest = [
+			"video/webm;codecs=vp9",
+			"video/webm",
+			"video/mp4;codecs=avc1.42E01E",
+			"video/mp4",
+		];
+		const supportedCodecs = available
+			? codecsToTest.filter((codec) => MediaRecorderService.isTypeSupported(codec))
+			: [];
 
-	return {
-		available,
-		isIOSSafari,
-		selectedCodec: selectedCodec || "(browser picks)",
-		supportedCodecs,
-	};
+		return {
+			available,
+			isIOSSafari,
+			selectedCodec: selectedCodec || "(browser picks)",
+			supportedCodecs,
+		};
+	} catch (err) {
+		console.error("[BugReport] Failed to collect MediaRecorder info:", err);
+		return {
+			available: false,
+			isIOSSafari: false,
+			selectedCodec: "(error during detection)",
+			supportedCodecs: [],
+		};
+	}
 }
 
 export function getMetadata(


### PR DESCRIPTION
## Summary

Follow-up to PR #39 addressing review findings:

- **Bug fix**: Wrap `getMediaRecorderInfo()` in try-catch so bug reporting never fails due to MediaRecorder detection errors. If detection throws, returns safe defaults with `selectedCodec: "(error during detection)"` instead of crashing the bug reporter.

- **Debugging improvement**: Add `console.warn` when codec selection falls back to empty string (letting browser pick). Helps diagnose codec issues on edge-case browsers.

## Test plan

- [x] Unit tests pass (543 tests)
- [x] Added test for error handling - verifies safe defaults returned when MediaRecorder throws
- [x] Verified console.warn is triggered in existing fallback test

## Files changed (3)

- `src/utils/bugReportFormatters.ts` - Added try-catch wrapper
- `src/utils/bugReportFormatters.test.ts` - Added error handling test
- `src/services/MediaRecorderService.ts` - Added console.warn for fallback paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)