### PR TITLE
Preserve aspect ratio in smart zoom processing canvas

### DIFF
--- a/src/components/CameraStage.tsx
+++ b/src/components/CameraStage.tsx
@@ -505,7 +505,7 @@ export function CameraStage() {
 						videoRef={videoRef}
 						isMirror={isMirror}
 					/>
-					<DetectPerfOverlay detectTimeMsRef={smartZoom.detectTimeMsRef} videoRef={videoRef} />
+					<DetectPerfOverlay detectTimeMsRef={smartZoom.detectTimeMsRef} videoRef={videoRef} processingResRef={smartZoom.processingResRef} />
 				</>
 			)}
 

--- a/src/components/DetectPerfOverlay.tsx
+++ b/src/components/DetectPerfOverlay.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 interface DetectPerfOverlayProps {
 	detectTimeMsRef: React.RefObject<number>;
 	videoRef: React.RefObject<HTMLVideoElement | null>;
+	processingResRef: React.RefObject<{ width: number; height: number }>;
 }
 
 /**
@@ -10,7 +11,7 @@ interface DetectPerfOverlayProps {
  * Uses refs and rAF to avoid React re-renders (same pattern as HandSkeleton).
  * Smooths the detect time with EMA to reduce jitter.
  */
-export function DetectPerfOverlay({ detectTimeMsRef, videoRef }: DetectPerfOverlayProps) {
+export function DetectPerfOverlay({ detectTimeMsRef, videoRef, processingResRef }: DetectPerfOverlayProps) {
 	const spanRef = useRef<HTMLSpanElement>(null);
 	const smoothedMsRef = useRef(0);
 
@@ -30,15 +31,16 @@ export function DetectPerfOverlay({ detectTimeMsRef, videoRef }: DetectPerfOverl
 				const video = videoRef.current;
 				const camRes = video ? `${video.videoWidth}×${video.videoHeight}` : "—";
 
+				const pr = processingResRef.current;
 				spanRef.current.textContent =
-					`Detect: ${smoothedMsRef.current.toFixed(1)}ms | Camera: ${camRes} | Process: 640×360`;
+					`Detect: ${smoothedMsRef.current.toFixed(1)}ms | Camera: ${camRes} | Process: ${pr.width}×${pr.height}`;
 			}
 			rafId = requestAnimationFrame(update);
 		};
 
 		update();
 		return () => cancelAnimationFrame(rafId);
-	}, [detectTimeMsRef, videoRef]);
+	}, [detectTimeMsRef, videoRef, processingResRef]);
 
 	return (
 		<div className="absolute top-2 left-2 z-50 pointer-events-none">

--- a/src/hooks/useSmartZoom.test.ts
+++ b/src/hooks/useSmartZoom.test.ts
@@ -4,6 +4,7 @@ import { HandLandmarkerService } from "../services/HandLandmarkerService";
 import {
 	clampNormalizedPan,
 	clampPanToViewport,
+	computeProcessingDimensions,
 	useSmartZoom,
 } from "./useSmartZoom";
 
@@ -527,5 +528,37 @@ describe("clampPanToViewport (legacy pixel-based)", () => {
 		expect(result.pan.y).toBe(-100); // Within bounds
 		expect(result.clampedEdges.right).toBe(true); // At -maxPanX
 		expect(result.clampedEdges.left).toBe(false);
+	});
+});
+
+describe("computeProcessingDimensions", () => {
+	it("should scale 16:9 landscape to 640x360", () => {
+		const result = computeProcessingDimensions(1920, 1080);
+		expect(result).toEqual({ width: 640, height: 360 });
+	});
+
+	it("should preserve 4:3 aspect ratio (640x480)", () => {
+		const result = computeProcessingDimensions(1280, 960);
+		expect(result).toEqual({ width: 640, height: 480 });
+	});
+
+	it("should handle portrait video (1080x1920 → 360x640)", () => {
+		const result = computeProcessingDimensions(1080, 1920);
+		expect(result).toEqual({ width: 360, height: 640 });
+	});
+
+	it("should not upscale small video (320x240 → 320x240)", () => {
+		const result = computeProcessingDimensions(320, 240);
+		expect(result).toEqual({ width: 320, height: 240 });
+	});
+
+	it("should handle square video (1000x1000 → 640x640)", () => {
+		const result = computeProcessingDimensions(1000, 1000);
+		expect(result).toEqual({ width: 640, height: 640 });
+	});
+
+	it("should respect custom maxDimension", () => {
+		const result = computeProcessingDimensions(1920, 1080, 320);
+		expect(result).toEqual({ width: 320, height: 180 });
 	});
 });

--- a/src/hooks/useSmartZoom.ts
+++ b/src/hooks/useSmartZoom.ts
@@ -106,6 +106,22 @@ export function clampPanToViewport(
 	return { pan: clampedPan, clampedEdges };
 }
 
+/**
+ * Compute processing canvas dimensions that preserve the source aspect ratio.
+ * Scales so the larger dimension fits within maxDimension; never upscales.
+ */
+export function computeProcessingDimensions(
+	videoWidth: number,
+	videoHeight: number,
+	maxDimension = 640,
+): { width: number; height: number } {
+	const scale = Math.min(1, maxDimension / Math.max(videoWidth, videoHeight));
+	return {
+		width: Math.round(videoWidth * scale),
+		height: Math.round(videoHeight * scale),
+	};
+}
+
 interface SmartZoomConfig {
 	videoRef: React.RefObject<HTMLVideoElement | null>;
 	enabled: boolean;
@@ -167,9 +183,11 @@ export function useSmartZoom({
 	const detectTimeMsRef = useRef(0);
 
 	// Offscreen canvas for downscaling video before detection
-	// MediaPipe's hand model works at 224x224 internally, so 640x360 is more than enough
+	// MediaPipe's hand model works at 224x224 internally, so 640-wide is more than enough
 	const processingCanvasRef = useRef<OffscreenCanvas | HTMLCanvasElement | null>(null);
 	const processingCtxRef = useRef<CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null>(null);
+	const lastVideoDimsRef = useRef({ width: 0, height: 0 });
+	const processingResRef = useRef({ width: 0, height: 0 });
 
 	const requestRef = useRef<number>(0);
 	const lastVideoTimeRef = useRef<number>(-1);
@@ -218,21 +236,33 @@ export function useSmartZoom({
 			if (video.currentTime !== lastVideoTimeRef.current) {
 				lastVideoTimeRef.current = video.currentTime;
 
-				// Lazily create offscreen processing canvas (once)
-				if (!processingCanvasRef.current) {
-					processingCanvasRef.current = document.createElement("canvas");
-					processingCanvasRef.current.width = 640;
-					processingCanvasRef.current.height = 360;
-					processingCtxRef.current = processingCanvasRef.current.getContext("2d");
+				// Create or resize processing canvas to match video aspect ratio
+				const vw = video.videoWidth;
+				const vh = video.videoHeight;
+				if (
+					!processingCanvasRef.current ||
+					lastVideoDimsRef.current.width !== vw ||
+					lastVideoDimsRef.current.height !== vh
+				) {
+					const dims = computeProcessingDimensions(vw, vh);
+					if (!processingCanvasRef.current) {
+						processingCanvasRef.current = document.createElement("canvas");
+					}
+					processingCanvasRef.current.width = dims.width;
+					processingCanvasRef.current.height = dims.height;
+					processingCtxRef.current = (processingCanvasRef.current as HTMLCanvasElement).getContext("2d");
+					lastVideoDimsRef.current = { width: vw, height: vh };
+					processingResRef.current = dims;
 				}
 
-				// Downscale video to 640x360 before detection.
+				// Downscale video preserving aspect ratio before detection.
 				// Falls back to raw video if drawImage fails (e.g. in jsdom tests).
 				let detectInput: HTMLVideoElement | HTMLCanvasElement = video;
 				const processingCtx = processingCtxRef.current;
+				const procRes = processingResRef.current;
 				if (processingCtx) {
 					try {
-						processingCtx.drawImage(video, 0, 0, 640, 360);
+						processingCtx.drawImage(video, 0, 0, procRes.width, procRes.height);
 						detectInput = processingCanvasRef.current as HTMLCanvasElement;
 					} catch {
 						// jsdom canvas doesn't support drawImage with video — use raw video
@@ -478,6 +508,7 @@ export function useSmartZoom({
 		clampedEdgesRef,
 		debugLandmarksRef,
 		detectTimeMsRef,
+		processingResRef,
 		getDebugTrace,
 	};
 }


### PR DESCRIPTION
## Summary
- **Fix**: Processing canvas was hardcoded to 640x360 (16:9), squishing 4:3/portrait camera feeds before MediaPipe hand detection — causing distorted landmarks and wrong pan/zoom calculations
- **Change**: Extract `computeProcessingDimensions()` pure function that scales the larger dimension to fit within 640px while preserving the source aspect ratio (never upscales)
- **Change**: Canvas now resizes dynamically when video dimensions change, and `DetectPerfOverlay` shows the actual processing resolution instead of hardcoded "640×360"

## Test plan
- [x] `just test` — all 550 tests pass (6 new tests for `computeProcessingDimensions`)
- [x] `just build` — no type errors
- [ ] Manual: verify with 4:3 webcam that hand tracking landmarks align correctly
- [ ] Manual: verify overlay shows correct processing resolution (e.g. "640×480" for 4:3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Processing resolution now dynamically adapts to video input dimensions, replacing fixed sizing for better compatibility with various video formats.
  * Performance metrics now display actual processing dimensions in real-time rather than hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->