### PR TITLE
test: recording E2E foundation (reliability sweep PR1)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-reliability-pr1-test-foundation.md
+++ b/docs/superpowers/plans/2026-07-20-reliability-pr1-test-foundation.md
@@ -1,0 +1,328 @@
+# Reliability Sweep PR1: Test Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the recording E2E path real — fix the always-broken MediaRecorder mock, type-check `tests/`, un-skip the two recording tests, and add the keystone record→session-appears test that currently doesn't exist.
+
+**Architecture:** Pure test-infrastructure PR (spec: `docs/superpowers/specs/2026-07-20-reliability-sweep-design.md`, Section 6 + PR1 in Section 7). No `src/` changes. Today every session E2E test seeds IndexedDB directly and both recording tests are skipped, so broken record→storage wiring would ship green. This PR makes later fix-PRs verifiable end-to-end.
+
+**Tech Stack:** Playwright (`tests/`), TypeScript project references (`tsc -b`), Vitest (unit, untouched).
+
+## Global Constraints
+
+- Branch: `pr/reliability-tests` off `origin/main` (NOT off the spec branch). Never push to main. Never `--no-verify`. Never `git add -A` without reviewing `git status` first.
+- Pre-commit runs Biome (tabs, double quotes) + unit tests automatically. If a hook reformats files, the commit silently no-ops — check for the `[branch sha]` confirmation line after every commit; if missing, re-stage and retry.
+- Never delete or weaken a failing test. If a new test fails against current `main`, that is a finding: mark it `test.fixme` with a comment describing observed behavior, and report it in the final summary — do not delete it.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- E2E commands need the dev server config Playwright manages itself (`npx playwright test` boots it). Run desktop project only: `--project=chromium`.
+
+---
+
+### Task 1: Deterministic MockMediaRecorder installation
+
+**Files:**
+- Modify: `tests/magic-monitor.spec.ts:181-193`
+
+**Interfaces:**
+- Produces: `injectMockCamera(page)` unchanged signature; after this task `window.MediaRecorder` is ALWAYS `MockMediaRecorder` in `magic-monitor.spec.ts` tests (deterministic).
+
+**Context:** Line 184 reads `new OriginalMediaRecorder(stream, ...)` but the variable in scope is `activeStream` (line 75) — `stream` is undefined, the `try` always throws, and the mock is always installed. The "prefer the real recorder" logic has never run. The comment at line 544 records that the real MediaRecorder is unreliable with canvas streams in headless Chrome, so the correct fix is to make the always-mock behavior intentional, not to resurrect the broken detection.
+
+- [ ] **Step 1: Replace the broken try/catch with unconditional mock install**
+
+In `tests/magic-monitor.spec.ts`, replace lines 181-192:
+
+```ts
+		// Only use mock if original doesn't work with our stream
+		// Test if the original MediaRecorder works
+		try {
+			const testRecorder = new OriginalMediaRecorder(stream, { mimeType: "video/webm" });
+			testRecorder.start();
+			testRecorder.stop();
+			console.log("Original MediaRecorder works with canvas stream");
+		} catch {
+			console.log("Original MediaRecorder failed, using mock");
+			// @ts-expect-error - overriding MediaRecorder
+			window.MediaRecorder = MockMediaRecorder;
+		}
+```
+
+with:
+
+```ts
+		// Always install the mock: MediaRecorder with canvas streams is
+		// unreliable in headless Chrome, and deterministic recording data
+		// is what the recording tests depend on.
+		// @ts-expect-error - overriding MediaRecorder
+		window.MediaRecorder = MockMediaRecorder;
+```
+
+Then delete the now-unused `const OriginalMediaRecorder = window.MediaRecorder;` at line 108 (Biome will flag the unused variable otherwise).
+
+- [ ] **Step 2: Verify existing E2E behavior is preserved**
+
+Run: `npx playwright test --project=chromium tests/magic-monitor.spec.ts -g "App loads"`
+Expected: PASS (mock was already always installed; this only removes the dead path).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/magic-monitor.spec.ts
+git commit -m "test: install MockMediaRecorder deterministically in E2E
+
+The real-recorder detection referenced an undefined variable (stream vs
+activeStream), so the try always threw and the mock was always installed.
+Make that behavior intentional; headless Chrome canvas-stream recording
+is unreliable per the existing comment.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Type-check `tests/` under `tsc -b`
+
+**Files:**
+- Create: `tsconfig.test.json`
+- Modify: `tsconfig.json` (add reference)
+- Modify: `tests/session-recorder.spec.ts:64`
+
+**Interfaces:**
+- Produces: `npx tsc -b` (and therefore `just build` / `just test`) now type-checks `tests/`. The undefined-variable bug class that hid Task 1's target can't recur.
+
+**Context:** `tsconfig.app.json` includes only `src`; `tsconfig.node.json` only `vite.config.ts`. Nothing checks `tests/`. A probe run found exactly two errors: the `stream` bug (fixed in Task 1) and one unsafe `window` cast.
+
+- [ ] **Step 1: Create `tsconfig.test.json`**
+
+```json
+{
+	"extends": "./tsconfig.node.json",
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+		"lib": ["ES2023", "DOM", "DOM.Iterable"]
+	},
+	"include": ["tests"]
+}
+```
+
+(Extends the node config for module/strictness settings; adds DOM libs because init scripts run in the browser context.)
+
+- [ ] **Step 2: Reference it from the root solution config**
+
+In `tsconfig.json`, change:
+
+```json
+	"references": [
+		{ "path": "./tsconfig.app.json" },
+		{ "path": "./tsconfig.node.json" }
+	]
+```
+
+to:
+
+```json
+	"references": [
+		{ "path": "./tsconfig.app.json" },
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.test.json" }
+	]
+```
+
+- [ ] **Step 3: Run the build to see the expected failure**
+
+Run: `npx tsc -b 2>&1 | head -10`
+Expected: FAIL with exactly one error:
+`tests/session-recorder.spec.ts(64,4): error TS2352: Conversion of type 'Window & typeof globalThis' ... Property 'counterCamera' is missing`
+
+(If the `stream` error also appears, Task 1 was not completed — stop and fix that first.)
+
+- [ ] **Step 4: Fix the cast**
+
+In `tests/session-recorder.spec.ts` line 64, change:
+
+```ts
+		(window as Window & { counterCamera: { getCounter: () => number; reset: () => void } }).counterCamera = {
+```
+
+to:
+
+```ts
+		(window as unknown as Window & { counterCamera: { getCounter: () => number; reset: () => void } }).counterCamera = {
+```
+
+- [ ] **Step 5: Verify clean build**
+
+Run: `npx tsc -b`
+Expected: exit 0, no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tsconfig.json tsconfig.test.json tests/session-recorder.spec.ts
+git commit -m "test: type-check tests/ via tsc -b
+
+Playwright specs were checked by nothing (tsconfig.app includes only src),
+which is how an undefined-variable bug in the MediaRecorder mock went
+unnoticed. Add tsconfig.test.json and fix the one cast error it surfaced.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Un-skip the two recording tests
+
+**Files:**
+- Modify: `tests/magic-monitor.spec.ts:544-576`
+
+**Interfaces:**
+- Consumes: deterministic MockMediaRecorder from Task 1 (emits a chunk every 1000ms while recording).
+- Produces: two live E2E tests asserting the REC indicator and the duration readout.
+
+**Context:** The skip comment ("MediaRecorder with canvas stream doesn't work reliably") is obsolete — the mock is now always installed. Test 1's `/REC|\d+:\d+/` regex matches the actual `● REC` span (`src/components/CameraStage.tsx:495`). Test 2 expects an `m:ss` duration, but the status bar actually renders `` {Math.floor(currentBlockDuration)}s | N sessions `` (`CameraStage.tsx:497-498`) — the test must be rewritten against the real UI, not un-skipped verbatim.
+
+- [ ] **Step 1: Un-skip and update both tests**
+
+Replace lines 544-576 with:
+
+```ts
+	test("Recording: Shows recording indicator when live", async ({ page }) => {
+		// Wait for app to load and start recording
+		const video = page.getByTestId("main-video");
+		await expect(video).toBeVisible();
+
+		// Recording indicator should show REC once video + storage are ready
+		const recordingIndicator = page.getByText("● REC");
+		await expect(recordingIndicator).toBeVisible({ timeout: 10000 });
+	});
+
+	test("Recording: Duration counter increases over time", async ({ page }) => {
+		// Wait for app to load
+		const video = page.getByTestId("main-video");
+		await expect(video).toBeVisible();
+
+		// Status bar shows "<seconds>s | <n> sessions" while live
+		// (.first() — the regex also matches ancestor spans; match innermost deterministically)
+		const statusReadout = page.getByText(/\d+s \|/).first();
+		await expect(statusReadout).toBeVisible({ timeout: 10000 });
+
+		const initialText = await statusReadout.textContent();
+
+		// Wait for the block duration to tick up
+		await expect(async () => {
+			const newText = await statusReadout.textContent();
+			expect(newText).not.toBe(initialText);
+		}).toPass({ timeout: 5000 });
+	});
+```
+
+- [ ] **Step 2: Run both tests**
+
+Run: `npx playwright test --project=chromium tests/magic-monitor.spec.ts -g "Recording:"`
+Expected: 2 passed.
+If either fails: investigate against current `main` behavior. A genuine failure (e.g. REC never appears with the mock recorder) is a finding for the sweep — mark the test `test.fixme` with a comment describing what was observed and report it; do not delete.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/magic-monitor.spec.ts
+git commit -m "test: un-skip recording indicator E2E tests
+
+The skip reason (unreliable canvas-stream MediaRecorder) is obsolete now
+that the mock is installed deterministically. Duration test rewritten to
+match the actual status readout format (Ns | M sessions).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Keystone test — recording produces a real session (no seeding)
+
+**Files:**
+- Modify: `tests/magic-monitor.spec.ts` (append inside the `test.describe("Magic Monitor E2E", ...)` block, after the duration test from Task 3)
+
+**Interfaces:**
+- Consumes: MockMediaRecorder chunks (Task 1); `● REC` indicator (Task 3).
+- Produces: the only E2E test exercising record → stop → save → appears-in-picker without `seedSessionBuffer`.
+
+**Context:** Opening the Sessions picker stops the current block and saves it (`CameraStage.tsx:235-241` → `stopCurrentBlock`), so a few seconds of recording then opening the picker must yield a Recent session. Every existing session test bypasses this via `tests/helpers/seedSessionBuffer.ts`. Picker selectors from existing tests: `page.getByRole("button", { name: "Sessions" })`, `page.getByRole("heading", { name: "Sessions" })`; empty state renders `No recent recordings` (`src/components/SessionPicker.tsx:250-253`).
+
+- [ ] **Step 1: Add the test**
+
+```ts
+	test("Recording: A real recorded block appears in Sessions without seeding", async ({ page }) => {
+		// Wait for recording to actually start
+		await expect(page.getByTestId("main-video")).toBeVisible();
+		await expect(page.getByText("● REC")).toBeVisible({ timeout: 10000 });
+
+		// Let the mock recorder emit at least two 1s chunks
+		await page.waitForTimeout(2500);
+
+		// Opening the picker stops and saves the current block
+		await page.getByRole("button", { name: "Sessions" }).click();
+		await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible();
+
+		// The just-recorded block must appear as a Recent session.
+		// This is the only test covering record→storage→picker for real;
+		// everything else seeds IndexedDB directly.
+		await expect(page.getByText("No recent recordings")).toBeHidden({ timeout: 10000 });
+	});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npx playwright test --project=chromium tests/magic-monitor.spec.ts -g "appears in Sessions"`
+Expected: PASS.
+If it fails with "No recent recordings" still visible: this is exactly the class of bug the sweep exists for (silent save failure / machine dead state). Mark `test.fixme` with the observed behavior and report it prominently — the fix lands in PR2, and this test becomes its acceptance criterion. Do not delete.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/magic-monitor.spec.ts
+git commit -m "test: keystone E2E - recorded block appears in Sessions unseeded
+
+First end-to-end coverage of record -> stop -> save -> picker. All other
+session tests seed IndexedDB directly, so broken recording wiring would
+ship green without this.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full desktop E2E suite**
+
+Run: `npx playwright test --project=chromium`
+Expected: all pass (4 skips maximum: the pre-existing `test.skip` zoom/pan tests; zero recording skips remain).
+
+- [ ] **Step 2: Unit suite + type-check via the real pipeline**
+
+Run: `just test`
+Expected: `tsc -b` clean (now includes tests/), 568+ unit tests pass.
+
+- [ ] **Step 3: Commit the plan doc, push, open PR**
+
+```bash
+git add docs/superpowers/plans/2026-07-20-reliability-pr1-test-foundation.md
+git commit -m "docs: PR1 test-foundation implementation plan
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin pr/reliability-tests
+gh pr create --title "test: recording E2E foundation (reliability sweep PR1)" --body "PR1 of 4 from the reliability sweep design (docs/superpowers/specs/2026-07-20-reliability-sweep-design.md).
+
+- Fix the MediaRecorder mock that was silently always-on due to an undefined variable, and install it deterministically
+- Type-check tests/ under tsc -b (the enabler that let that bug hide)
+- Un-skip both recording indicator tests (duration test rewritten to match the real status readout)
+- Add the keystone test: a real recorded block appears in Sessions without IndexedDB seeding
+
+No src/ changes. Makes PR2-PR4 verifiable end-to-end.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Expected: PR URL printed. Report any `test.fixme` findings from Tasks 3-4 in the PR body and the session summary.

--- a/docs/superpowers/plans/2026-07-20-reliability-pr2-recorder-machine.md
+++ b/docs/superpowers/plans/2026-07-20-reliability-pr2-recorder-machine.md
@@ -1,0 +1,1146 @@
+# Reliability Sweep PR2: Recorder Machine Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recording never silently dies: no dead-end machine states (H2), no stale-stop clobbering (H3), mid-block recorder failures are observed and recovered (M1), save errors don't masquerade as storage death (M8), camera switches stop/save/resume cleanly (H4), and the REC indicator tells the truth.
+
+**Architecture:** Spec: `docs/superpowers/specs/2026-07-20-reliability-sweep-design.md` Section 2 (also on branch `pr/reliability-sweep-spec`; fetch via `git show origin/pr/reliability-sweep-spec:docs/...` if absent). All changes live in `SessionRecorderMachine` + its adapters (`useSessionRecorder`, `useBlockRecorder`), `MediaRecorderService`, `useSessionList` (one new field), and the CameraStage status bar. The machine stays pure (no React, no timers, injected callbacks + clock).
+
+**Tech Stack:** TypeScript, Vitest (+ @testing-library/react renderHook), existing DI seams (`timerService`, `mediaRecorderService`, `sessionStorageService`).
+
+## Global Constraints
+
+- Branch: `pr/reliability-recorder` off `origin/main` **rebased onto / branched from the merged PR1 state** — if PR1 (`pr/reliability-tests`) is not yet merged, branch off `pr/reliability-tests` instead so the E2E foundation (deterministic mock, port 5273, un-skipped recording tests, keystone test) is present. Never push to main. Never `--no-verify`. Never `git add -A` without reviewing `git status`.
+- Pre-commit runs Biome (tabs, double quotes) + checks; watch for the `[branch sha]` confirmation line after each commit — if missing, re-stage and retry.
+- TDD per bug: failing test FIRST, watch it fail, then fix. TDD evidence (RED output, GREEN output) goes in the report.
+- Never delete a failing test. Exception, explicitly sanctioned here: `SessionRecorderMachine.test.ts:184` ("transitions to waitingForVideo if still enabled and ready") codifies bug H2 as intended behavior — Task 2 REWRITES this test's assertion to the new contract. That is a deliberate contract change, not a test deletion; the commit message must say so.
+- CPU discipline: prefix every test-suite/E2E/build run with `nice -n 19 ionice -c 3`; Playwright runs use `--workers=2`.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Machine purity: `SessionRecorderMachine.ts` must not import React, timers, or services — inputs and injected callbacks only.
+- Spec deviations already adjudicated (do not re-litigate in-task): (a) H4 moves fully into this PR (spec Section 7 listed it under PR3, but every file it touches is a PR2 file); (b) the generation token lives in `useBlockRecorder`, not the machine — the refs it protects live there, and the machine's state guard (`"stopping"` blocks re-entry) already serializes machine-level stops once Task 2 lands; (c) `enable()`/`videoIsReady()`/`storageInitialized()` KEEP their early-return guards — they are safe once `stopCurrentBlock` always re-runs the transition ladder (Task 2), and removing them would invite re-entrant transitions.
+
+## Verification commands
+
+- Focused: `nice -n 19 ionice -c 3 npx vitest run src/machines/SessionRecorderMachine.test.ts` (substitute file under test)
+- Full unit: `nice -n 19 ionice -c 3 npx vitest run`
+- Type check: `npx tsc -b`
+- E2E (Task 9 only): `nice -n 19 ionice -c 3 npx playwright test --project=chromium --workers=2`
+
+---
+
+### Task 1: `useLatest` helper + collapse the 7× ref-mirroring
+
+**Files:**
+- Create: `src/hooks/useLatest.ts`
+- Create: `src/hooks/useLatest.test.ts`
+- Modify: `src/hooks/useSessionRecorder.ts:105-142` (the two mirror blocks)
+
+**Interfaces:**
+- Produces: `useLatest<T>(value: T): React.RefObject<T>` — later tasks (5) mirror new callbacks with it.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/hooks/useLatest.test.ts`:
+
+```typescript
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useLatest } from "./useLatest";
+
+describe("useLatest", () => {
+	it("returns a ref holding the latest value across re-renders", () => {
+		const { result, rerender } = renderHook(({ value }) => useLatest(value), {
+			initialProps: { value: 1 },
+		});
+		const firstRef = result.current;
+		expect(firstRef.current).toBe(1);
+
+		rerender({ value: 2 });
+		expect(result.current).toBe(firstRef); // stable ref identity
+		expect(result.current.current).toBe(2); // latest value
+	});
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`Cannot find module './useLatest'`)
+
+Run: `nice -n 19 ionice -c 3 npx vitest run src/hooks/useLatest.test.ts`
+
+- [ ] **Step 3: Implement `src/hooks/useLatest.ts`**
+
+```typescript
+import { useEffect, useRef } from "react";
+
+/**
+ * Returns a ref that always holds the latest value.
+ * Use to hand fresh callbacks to long-lived consumers (state machines,
+ * event handlers) without recreating them.
+ */
+export function useLatest<T>(value: T): React.RefObject<T> {
+	const ref = useRef(value);
+	useEffect(() => {
+		ref.current = value;
+	});
+	return ref;
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Refactor `useSessionRecorder.ts`**
+
+Replace lines 105-119 (5 refs + sync effect) and lines 136-142 (2 rotation refs + sync effect) with:
+
+```typescript
+	// Latest-callback refs so the machine never needs to be recreated
+	const startRecordingRef = useLatest(startRecording);
+	const stopRecordingRef = useLatest(stopRecording);
+	const startCaptureRef = useLatest(startCapture);
+	const stopCaptureRef = useLatest(stopCapture);
+	const saveBlockRef = useLatest(saveBlock);
+```
+
+and (after the `useBlockRotation` destructure, replacing the second mirror block):
+
+```typescript
+	const startRotationRef = useLatest(startRotation);
+	const stopRotationRef = useLatest(stopRotation);
+```
+
+Add `import { useLatest } from "./useLatest";` and remove the now-unused mirror `useEffect`s. All consumer sites (`startRecordingRef.current()` etc. in the machine-construction effect) are unchanged — `useLatest` returns the same `.current` shape.
+
+- [ ] **Step 6: Verify no behavior change**
+
+Run: `nice -n 19 ionice -c 3 npx vitest run src/hooks/useSessionRecorder.test.ts src/hooks/useLatest.test.ts`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks/useLatest.ts src/hooks/useLatest.test.ts src/hooks/useSessionRecorder.ts
+git commit -m "refactor: collapse hand-rolled ref mirrors into useLatest helper
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: H2 — no dead-end states in the machine
+
+**Files:**
+- Modify: `src/machines/SessionRecorderMachine.ts` (`stopCurrentBlock` lines 156-186, `tryTransition` lines 198-230, `blockTimerFired` lines 141-150)
+- Modify: `src/machines/SessionRecorderMachine.test.ts` (rewrite test at line 184; add three tests)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `stopCurrentBlock()` now ends by re-running the transition ladder — after a manual stop with everything still ready, the machine is `{ type: "recording" }` again (new contract relied on by Tasks 4, 5, 6).
+- Public API unchanged: `tryTransition` stays private; its new options parameter is internal.
+
+**Context — the bug:** `stopCurrentBlock()` manually parks in `waitingForVideo` (line 180) and nothing ever escapes: `enable()`/`storageInitialized()`/`videoIsReady()` all early-return because their flags are already true. Both UI entry points (`handleOpenPicker`, `handleStopAndViewRecording` in CameraStage) hit this. `blockTimerFired` works around it with bespoke duplicate logic (lines 146-149) that this task absorbs.
+
+- [ ] **Step 1: Rewrite the codified-bug test + add failing tests**
+
+In `SessionRecorderMachine.test.ts`, replace the test at lines 184-192 with:
+
+```typescript
+		it("starts the next block immediately when still enabled and ready", async () => {
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+
+			await machine.stopCurrentBlock();
+
+			// Contract change (H2 fix): a completed stop re-runs the transition
+			// ladder instead of parking in waitingForVideo forever.
+			expect(machine.getState()).toEqual({ type: "recording", blockStart: 1000 });
+			expect(callbacks.onStartRecording).toHaveBeenCalledTimes(2);
+		});
+```
+
+Add inside `describe("stopCurrentBlock")`:
+
+```typescript
+		it("recovers when disable() interleaves with an in-flight stop (pause/resume race)", async () => {
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+
+			// Hold the stop open so we can interleave inputs mid-flight
+			let resolveStop!: (v: { blob: Blob; duration: number }) => void;
+			callbacks.onStopRecording.mockReturnValueOnce(
+				new Promise((r) => {
+					resolveStop = r;
+				}),
+			);
+
+			const stopPromise = machine.stopCurrentBlock();
+			machine.disable(); // pause while stopping
+			machine.enable(); // resume while still stopping
+			resolveStop({ blob: new Blob(["x"], { type: "video/webm" }), duration: 1000 });
+			await stopPromise;
+
+			expect(machine.getState().type).toBe("recording");
+		});
+
+		it("returns to waitingForVideo (and later resumes) if video went away during stop", async () => {
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+
+			let resolveStop!: (v: { blob: Blob; duration: number }) => void;
+			callbacks.onStopRecording.mockReturnValueOnce(
+				new Promise((r) => {
+					resolveStop = r;
+				}),
+			);
+
+			const stopPromise = machine.stopCurrentBlock();
+			machine.videoNotReady();
+			resolveStop({ blob: new Blob(["x"], { type: "video/webm" }), duration: 1000 });
+			await stopPromise;
+
+			expect(machine.getState()).toEqual({ type: "waitingForVideo" });
+
+			machine.videoIsReady();
+			expect(machine.getState().type).toBe("recording");
+		});
+```
+
+Note on `disable()` during `"stopping"`: `disable()`'s else-branch sets `{ type: "idle" }` while a stop is in flight — that's fine; the completing stop re-runs the ladder and `enable()`'s call above re-set `enabled = true` before it completes.
+
+- [ ] **Step 2: Run — expect the three tests to FAIL** (first: state is `waitingForVideo`, `onStartRecording` called once)
+
+Run: `nice -n 19 ionice -c 3 npx vitest run src/machines/SessionRecorderMachine.test.ts`
+
+- [ ] **Step 3: Implement**
+
+In `SessionRecorderMachine.ts`:
+
+Replace `stopCurrentBlock` lines 178-183 (the manual transition) so the method ends:
+
+```typescript
+		// Never park: re-run the transition ladder now that the stop is done (H2).
+		this.tryTransition({ fromStop: true });
+
+		return savedSession;
+```
+
+Change `tryTransition` signature and the final guard:
+
+```typescript
+	/**
+	 * Attempt to transition based on current conditions.
+	 * `fromStop` marks the call that completes an in-flight stop — it alone
+	 * may leave the "stopping" state.
+	 */
+	private tryTransition(options: { fromStop?: boolean } = {}): void {
+		// Not enabled? Stay idle
+		if (!this.enabled) {
+			if (this.state.type !== "idle") {
+				this.setState({ type: "idle" });
+			}
+			return;
+		}
+
+		// Enabled but storage not ready? Initialize
+		if (!this.storageReady) {
+			if (this.state.type !== "initializing") {
+				this.setState({ type: "initializing" });
+			}
+			return;
+		}
+
+		// Storage ready but video not ready? Wait
+		if (!this.videoReady) {
+			if (this.state.type !== "waitingForVideo") {
+				this.setState({ type: "waitingForVideo" });
+			}
+			return;
+		}
+
+		// Everything ready and nothing in flight? Start!
+		if (
+			this.state.type !== "recording" &&
+			(this.state.type !== "stopping" || options.fromStop)
+		) {
+			this.startRecordingBlock();
+		}
+	}
+```
+
+Simplify `blockTimerFired` — its bespoke restart is now redundant:
+
+```typescript
+	/**
+	 * Called when the block rotation timer fires.
+	 * Completes the current block; the completing transition starts the next
+	 * one if still enabled and ready.
+	 */
+	async blockTimerFired(): Promise<void> {
+		if (this.state.type !== "recording") return;
+		await this.stopCurrentBlock();
+	}
+```
+
+- [ ] **Step 4: Run the machine suite — expect ALL PASS** (including the untouched `blockTimerFired` describe block: "stops current block and starts new one" now passes via the generalized path)
+
+Run: `nice -n 19 ionice -c 3 npx vitest run src/machines/SessionRecorderMachine.test.ts`
+
+- [ ] **Step 5: Full unit suite** — `useSessionRecorder.test.ts` exercises the machine through the hook; confirm nothing depended on the parked state.
+
+Run: `nice -n 19 ionice -c 3 npx vitest run`
+Expected: all pass. If a hook test asserted the old parking behavior, rewrite its expectation with the same justification as Step 1 and note it in the report.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/machines/SessionRecorderMachine.ts src/machines/SessionRecorderMachine.test.ts
+git commit -m "fix: recorder machine never parks in a dead state after a stop (H2)
+
+stopCurrentBlock re-runs the transition ladder when the stop completes,
+so stop-and-view and pause/resume races resume recording instead of
+wedging in waitingForVideo. blockTimerFired's bespoke restart is now
+redundant and removed. Rewrites the test that codified the parked state
+as intended behavior - deliberate contract change.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: H3 — generation token in `useBlockRecorder`
+
+**Files:**
+- Modify: `src/hooks/useBlockRecorder.ts` (`startRecording` lines 60-133, `stopRecording` lines 144-175)
+- Modify: `src/hooks/useBlockRecorder.test.ts` (add one test)
+
+**Interfaces:**
+- Public shapes unchanged (`BlockRecorderConfig`, `BlockRecorderControls`, `StopRecordingOptions`).
+- Produces: internal `generationRef` pattern; Task 5's `onFailure` handler reuses the same `generation` capture.
+
+**Context — the bug:** `stopRecording` captures `session` then awaits `session.stop()`; if a new `startRecording` runs during that await, the stale stop's lines 155-156 null `recordingSessionRef` and stop `clonedStreamRef`'s tracks — which by then belong to the NEW block. Additionally, `startRecording` overwrites `clonedStreamRef` without stopping the previous clone, so the guard alone would leak the old clone — `startRecording` must clean up first.
+
+- [ ] **Step 1: Write the failing test**
+
+In `useBlockRecorder.test.ts` (match the file's existing mock/`renderHook` setup — it already builds a mock `mediaRecorderService` and a video ref with `srcObject`; follow its patterns exactly):
+
+```typescript
+	it("a stale stop does not clobber a newer recording session", async () => {
+		let resolveStopA!: (v: { blob: Blob; duration: number }) => void;
+		const sessionA = {
+			start: vi.fn(),
+			getState: vi.fn().mockReturnValue("recording"),
+			stop: vi.fn().mockReturnValue(
+				new Promise<{ blob: Blob; duration: number }>((r) => {
+					resolveStopA = r;
+				}),
+			),
+		};
+		const sessionB = {
+			start: vi.fn(),
+			getState: vi.fn().mockReturnValue("recording"),
+			stop: vi.fn().mockResolvedValue({
+				blob: new Blob(["b"], { type: "video/webm" }),
+				duration: 1000,
+			}),
+		};
+		mediaRecorderService.startRecording
+			.mockReturnValueOnce(sessionA)
+			.mockReturnValueOnce(sessionB);
+
+		const { result } = renderHookWithVideo(); // use the file's existing helper for a ready video ref
+
+		act(() => {
+			result.current.startRecording(); // block A
+		});
+		let stalePromise!: Promise<{ blob: Blob; duration: number } | null>;
+		act(() => {
+			stalePromise = result.current.stopRecording(); // A's stop, held open
+		});
+		act(() => {
+			result.current.startRecording(); // block B starts while A's stop is in flight
+		});
+		resolveStopA({ blob: new Blob(["a"], { type: "video/webm" }), duration: 500 });
+		await act(async () => {
+			await stalePromise;
+		});
+
+		// The stale stop must NOT null out B's session: getState reads the live ref.
+		expect(result.current.getState()).toBe("recording");
+	});
+```
+
+(If the file has no ready-video helper, construct the video ref the same way its existing `startRecording` tests do.)
+
+- [ ] **Step 2: Run — expect FAIL** (`getState()` returns `"inactive"`: the stale stop nulled the ref)
+
+Run: `nice -n 19 ionice -c 3 npx vitest run src/hooks/useBlockRecorder.test.ts`
+
+- [ ] **Step 3: Implement**
+
+In `useBlockRecorder.ts` add below the refs (line ~59):
+
+```typescript
+	// Generation token: each start owns a generation; a stale stop resolving
+	// after a newer start must not touch the newer block's refs (H3).
+	const generationRef = useRef(0);
+```
+
+In `startRecording`, at the top of the callback body (before reading `videoRef`):
+
+```typescript
+		const generation = ++generationRef.current;
+		// A previous block's clone is ours to release before cloning anew —
+		// the stale stop no longer cleans up across generations.
+		cleanupClonedStream();
+```
+
+(`cleanupClonedStream` is declared with `useCallback` below `startRecording` in the current file — move the `cleanupClonedStream` declaration ABOVE `startRecording` so it's in scope, keeping its body identical. Add `generation` to nothing else yet; Task 5 uses it.)
+
+In `stopRecording`, capture the generation and gate both cleanup blocks:
+
+```typescript
+			const generation = generationRef.current;
+			const session = recordingSessionRef.current;
+			if (!session || session.getState() !== "recording") {
+				cleanupClonedStream();
+				return null;
+			}
+
+			try {
+				const result = await session.stop();
+				if (generationRef.current === generation) {
+					recordingSessionRef.current = null;
+					cleanupClonedStream();
+					if (!forCleanup) {
+						setIsRecording(false);
+					}
+				}
+				return result;
+			} catch (err) {
+				console.error("Failed to stop recording:", err);
+				if (generationRef.current === generation) {
+					recordingSessionRef.current = null;
+					cleanupClonedStream();
+					if (!forCleanup) {
+						setError("Recording may have been lost - please try again");
+						setIsRecording(false);
+					}
+				}
+				return null;
+			}
+```
+
+Also add `startRecording`'s dependency array entry for `cleanupClonedStream` (it now calls it): `[videoRef, mediaRecorderService, timerService, deviceService, cleanupClonedStream]`.
+
+- [ ] **Step 4: Run — expect PASS**, then the whole file's suite
+
+Run: `nice -n 19 ionice -c 3 npx vitest run src/hooks/useBlockRecorder.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useBlockRecorder.ts src/hooks/useBlockRecorder.test.ts
+git commit -m "fix: stale stop can no longer clobber a newer recording block (H3)
+
+Each startRecording takes a generation; a stopRecording that resolves
+after a newer start skips the ref-null/stream-cleanup that would kill
+the newer block. startRecording releases the previous clone itself.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: M8 — save failures are not storage death
+
+**Files:**
+- Modify: `src/hooks/useSessionList.ts` (new `initFailed` state + interface + return)
+- Modify: `src/hooks/useSessionRecorder.ts:205-214` (storage effect keys on `initFailed`)
+- Modify: `src/machines/SessionRecorderMachine.ts` (consecutive save-failure counter)
+- Modify: `src/machines/SessionRecorderMachine.test.ts`, `src/hooks/useSessionRecorder.test.ts` (new tests)
+
+**Interfaces:**
+- Produces: `useSessionList` return gains `initFailed: boolean` (set only by the one-time init catch at `useSessionList.ts:56-57`). Machine gains `getConsecutiveSaveFailures(): number` (consumed by Task 7's reason accessor).
+
+- [ ] **Step 1: Failing machine test** — in `SessionRecorderMachine.test.ts`, new describe:
+
+```typescript
+	describe("save-failure resilience (M8)", () => {
+		it("keeps rotating blocks and counts consecutive save failures", async () => {
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+
+			callbacks.onSaveBlock.mockResolvedValueOnce(null); // save fails
+			await machine.stopCurrentBlock();
+
+			expect(machine.getConsecutiveSaveFailures()).toBe(1);
+			expect(machine.getState().type).toBe("recording"); // still rotating
+
+			callbacks.onSaveBlock.mockResolvedValueOnce({} as never); // save succeeds
+			await machine.stopCurrentBlock();
+			expect(machine.getConsecutiveSaveFailures()).toBe(0); // reset on success
+		});
+	});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`getConsecutiveSaveFailures is not a function`)
+
+- [ ] **Step 3: Implement machine side** — in `SessionRecorderMachine.ts`:
+
+Add field + accessor:
+
+```typescript
+	private consecutiveSaveFailures = 0;
+```
+
+```typescript
+	getConsecutiveSaveFailures(): number {
+		return this.consecutiveSaveFailures;
+	}
+```
+
+In `stopCurrentBlock`, after the `onSaveBlock` await:
+
+```typescript
+		if (result && result.blob.size > 0) {
+			savedSession = await this.callbacks.onSaveBlock(
+				result.blob,
+				result.duration,
+				thumbnails,
+				blockStart,
+			);
+			this.consecutiveSaveFailures =
+				savedSession === null ? this.consecutiveSaveFailures + 1 : 0;
+		}
+```
+
+In `enable()`, reset the counter so a user-driven resume retries fresh:
+
+```typescript
+	enable(): void {
+		if (this.enabled) return;
+		this.enabled = true;
+		this.consecutiveSaveFailures = 0;
+		this.tryTransition();
+	}
+```
+
+- [ ] **Step 4: Machine tests PASS**, then the wiring. In `useSessionList.ts`:
+
+Add state next to `error` (line ~42): `const [initFailed, setInitFailed] = useState(false);`
+In the init catch (lines 56-57), add `setInitFailed(true);` alongside the existing `setError`.
+Add `initFailed: boolean;` to the hook's return interface (the `error: string | null;` line ~21 is in that interface) and `initFailed,` to the return object.
+
+In `useSessionRecorder.ts`, replace the storage effect (lines 205-214):
+
+```typescript
+	// Storage initialization effect: only genuine init failure kills recording.
+	// Save/refresh errors stay in sessionList.error for display (M8).
+	useEffect(() => {
+		if (sessionList.initFailed) {
+			machineRef.current?.storageInitFailed();
+		} else if (isInitialized) {
+			machineRef.current?.storageInitialized();
+		}
+	}, [sessionList.initFailed, isInitialized]);
+```
+
+- [ ] **Step 5: Failing-then-passing hook test** — in `useSessionRecorder.test.ts` (use its existing mock services; `saveSessionWithBlob` rejection makes `saveBlock` return null and set `error`):
+
+```typescript
+	it("a failed block save does not permanently halt recording (M8)", async () => {
+		const storage = createMockSessionStorage();
+		storage.saveSessionWithBlob.mockRejectedValueOnce(new Error("disk full"));
+		// ...render the hook enabled with a ready video per the file's existing patterns,
+		// drive one block stop via the exposed stopCurrentBlock()...
+		// Assert: after the failed save, the machine starts the next block:
+		// isRecording returns true again (waitFor), rather than the pre-fix
+		// permanent idle caused by storageInitFailed().
+	});
+```
+
+Write this test concretely against the file's existing helpers (`createMockSessionStorage`, ready-video setup, `waitFor`) — the assertion is `await waitFor(() => expect(result.current.isRecording).toBe(true));` after a `stopCurrentBlock()` whose save failed. Verify it FAILS against the pre-fix wiring by temporarily reverting the effect if needed (or trust RED from writing it before Step 4's wiring — order the steps so this test exists before editing `useSessionRecorder.ts`).
+
+- [ ] **Step 6: Full unit suite + commit**
+
+```bash
+git add src/hooks/useSessionList.ts src/hooks/useSessionRecorder.ts src/machines/SessionRecorderMachine.ts src/machines/SessionRecorderMachine.test.ts src/hooks/useSessionRecorder.test.ts
+git commit -m "fix: transient save errors no longer masquerade as storage death (M8)
+
+useSessionList exposes initFailed separately from its shared error
+string; the recorder wires storageInitFailed to genuine init failure
+only. The machine counts consecutive save failures (reset on success
+and on re-enable) and keeps rotating blocks.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: M1 — mid-block recorder death is observed and recovered
+
+**Files:**
+- Modify: `src/services/MediaRecorderService.ts` (`MediaRecorderConfig`, `startRecording` lines 99-162)
+- Modify: `src/services/MediaRecorderService.test.ts` (new tests)
+- Modify: `src/hooks/useBlockRecorder.ts` (pass `onFailure`; new `onRecorderFailure` config callback)
+- Modify: `src/hooks/useSessionRecorder.ts` (wire to machine)
+- Modify: `src/machines/SessionRecorderMachine.ts` + test (new `recorderFailed` input, failure-park threshold)
+
+**Interfaces:**
+- `MediaRecorderConfig` gains `onFailure?: (salvaged: RecordingChunk | null) => void` — fires when the recorder errors or stops WITHOUT `stop()` having been requested. Salvage is best-effort: without a `start(timeslice)` there are usually no chunks yet, so `salvaged` is typically `null`. Deliberate: adding a timeslice risks fragmented-MP4 breakage on iOS Safari, out of scope.
+- `BlockRecorderConfig` gains `onRecorderFailure?: (salvaged: { blob: Blob; duration: number } | null) => void`.
+- Machine gains `async recorderFailed(salvaged: { blob: Blob; duration: number } | null): Promise<void>` and parks (visible, Task 7) after `3` consecutive mid-block failures (`enable()` resets the counter — same reset added in Task 4).
+
+- [ ] **Step 1: Failing service test** — in `MediaRecorderService.test.ts` (it already constructs sessions against a mocked/global MediaRecorder; follow its setup):
+
+```typescript
+	it("fires onFailure with best-effort salvage when the recorder errors mid-block", () => {
+		const onFailure = vi.fn();
+		const session = MediaRecorderService.startRecording(stream, { onFailure });
+		session.start();
+
+		// Simulate mid-block death: fire the recorder's error handler directly
+		recorderInstance.onerror?.(new Event("error"));
+
+		expect(onFailure).toHaveBeenCalledTimes(1);
+		expect(onFailure).toHaveBeenCalledWith(null); // no chunks yet -> nothing to salvage
+	});
+
+	it("does NOT fire onFailure for a requested stop", async () => {
+		const onFailure = vi.fn();
+		const session = MediaRecorderService.startRecording(stream, { onFailure });
+		session.start();
+		recorderInstance.state = "recording";
+
+		const stopPromise = session.stop();
+		recorderInstance.onstop?.(); // the stop() promise's own handler resolves it
+		await stopPromise;
+
+		expect(onFailure).not.toHaveBeenCalled();
+	});
+```
+
+(`recorderInstance` = however the existing tests reach the constructed mock recorder; reuse their mechanism.)
+
+- [ ] **Step 2: Run — expect FAIL**, then implement in `MediaRecorderService.ts`:
+
+Extend the config interface:
+
+```typescript
+export interface MediaRecorderConfig {
+	videoBitsPerSecond?: number;
+	/**
+	 * Fires when the recorder dies mid-block (error event, or a stop that was
+	 * never requested). Salvage is best-effort and usually null - without a
+	 * timeslice no chunks exist until stop.
+	 */
+	onFailure?: (salvaged: RecordingChunk | null) => void;
+}
+```
+
+In `startRecording`, after `const startTime = Date.now();` add:
+
+```typescript
+		let stopRequested = false;
+
+		const salvage = (): RecordingChunk | null => {
+			if (chunks.length === 0) return null;
+			const blob = new Blob(chunks, { type: mimeType });
+			chunks.length = 0;
+			return { blob, duration: Date.now() - startTime };
+		};
+
+		const handleMidBlockDeath = () => {
+			if (stopRequested) return; // stop() owns the handlers from here on
+			recorder.ondataavailable = null;
+			recorder.onstop = null;
+			recorder.onerror = null;
+			config.onFailure?.(salvage());
+		};
+```
+
+In the returned object's `start()`, after assigning `ondataavailable`, add:
+
+```typescript
+				recorder.onerror = handleMidBlockDeath;
+				recorder.onstop = handleMidBlockDeath;
+```
+
+In `stop()`, first line of the method body (before the `new Promise`):
+
+```typescript
+				stopRequested = true;
+```
+
+(The promise executor then reassigns `onstop`/`onerror` to its own handlers exactly as today.)
+
+- [ ] **Step 3: Service tests PASS. Failing machine test** — in `SessionRecorderMachine.test.ts`:
+
+```typescript
+	describe("recorderFailed (M1)", () => {
+		function startRecordingMachine() {
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+		}
+
+		it("salvages what it can and restarts recording", async () => {
+			startRecordingMachine();
+
+			await machine.recorderFailed({
+				blob: new Blob(["salvaged"], { type: "video/webm" }),
+				duration: 1200,
+			});
+
+			expect(callbacks.onStopBlockTimer).toHaveBeenCalled();
+			expect(callbacks.onStopThumbnails).toHaveBeenCalled();
+			expect(callbacks.onStopRecording).not.toHaveBeenCalled(); // recorder already dead
+			expect(callbacks.onSaveBlock).toHaveBeenCalledTimes(1);
+			expect(machine.getState().type).toBe("recording"); // restarted
+		});
+
+		it("restarts without saving when nothing was salvaged", async () => {
+			startRecordingMachine();
+			await machine.recorderFailed(null);
+			expect(callbacks.onSaveBlock).not.toHaveBeenCalled();
+			expect(machine.getState().type).toBe("recording");
+		});
+
+		it("parks after 3 consecutive failures instead of hot-looping", async () => {
+			startRecordingMachine();
+			await machine.recorderFailed(null);
+			await machine.recorderFailed(null);
+			await machine.recorderFailed(null);
+			expect(machine.getState()).toEqual({ type: "idle" });
+
+			// User-driven resume retries fresh
+			machine.disable();
+			machine.enable();
+			expect(machine.getState().type).toBe("recording");
+		});
+
+		it("ignores failure reports when not recording", async () => {
+			await machine.recorderFailed(null);
+			expect(callbacks.onStopBlockTimer).not.toHaveBeenCalled();
+		});
+	});
+```
+
+- [ ] **Step 4: Implement machine side** — in `SessionRecorderMachine.ts`:
+
+```typescript
+	private consecutiveRecorderFailures = 0;
+```
+
+(also reset it in `enable()` next to the Task 4 reset):
+
+```typescript
+		this.consecutiveSaveFailures = 0;
+		this.consecutiveRecorderFailures = 0;
+```
+
+New input method (place after `blockTimerFired`):
+
+```typescript
+	/**
+	 * Called when the recorder died mid-block (the adapter already cleaned up
+	 * its refs/stream). Salvages what was captured, then restarts - unless
+	 * failures are repeating, in which case park visibly rather than hot-loop.
+	 */
+	async recorderFailed(
+		salvaged: { blob: Blob; duration: number } | null,
+	): Promise<void> {
+		if (this.state.type !== "recording") return;
+
+		const blockStart = this.state.blockStart;
+		this.setState({ type: "stopping" });
+
+		this.callbacks.onStopBlockTimer();
+		const thumbnails = this.callbacks.onStopThumbnails();
+		// No onStopRecording: the recorder is already dead.
+
+		if (salvaged && salvaged.blob.size > 0) {
+			const saved = await this.callbacks.onSaveBlock(
+				salvaged.blob,
+				salvaged.duration,
+				thumbnails,
+				blockStart,
+			);
+			this.consecutiveSaveFailures =
+				saved === null ? this.consecutiveSaveFailures + 1 : 0;
+		}
+
+		this.consecutiveRecorderFailures += 1;
+		if (this.consecutiveRecorderFailures >= 3) {
+			this.setState({ type: "idle" });
+			return;
+		}
+
+		this.tryTransition({ fromStop: true });
+	}
+```
+
+Reset the recorder-failure counter on a successful NORMAL stop — in `stopCurrentBlock`, next to the save-outcome bookkeeping from Task 4, add after a successful save (`savedSession !== null`): the ternary already resets `consecutiveSaveFailures`; add one line after the `if (result && ...)` block:
+
+```typescript
+		if (savedSession !== null) {
+			this.consecutiveRecorderFailures = 0;
+		}
+```
+
+- [ ] **Step 5: Wire the chain.** In `useBlockRecorder.ts`:
+
+`BlockRecorderConfig` gains:
+
+```typescript
+	/** Fires when the active recorder dies mid-block (after local cleanup). */
+	onRecorderFailure?: (salvaged: { blob: Blob; duration: number } | null) => void;
+```
+
+Destructure it in the hook signature, mirror it: `const onRecorderFailureRef = useLatest(onRecorderFailure);` (import `useLatest` from Task 1).
+
+In `startRecording`, the service call becomes:
+
+```typescript
+			const session = mediaRecorderService.startRecording(stream, {
+				videoBitsPerSecond: getVideoBitrate(deviceService),
+				onFailure: (salvaged) => {
+					if (generationRef.current !== generation) return; // a dead PAST block is old news
+					recordingSessionRef.current = null;
+					cleanupClonedStream();
+					setIsRecording(false);
+					setError("Recording failed mid-block");
+					onRecorderFailureRef.current?.(salvaged);
+				},
+			});
+```
+
+In `useSessionRecorder.ts`, pass it where `useBlockRecorder` is invoked (line ~85):
+
+```typescript
+	const blockRecorder = useBlockRecorder({
+		videoRef,
+		mediaRecorderService,
+		timerService,
+		onRecorderFailure: (salvaged) => {
+			machineRef.current?.recorderFailed(salvaged);
+		},
+	});
+```
+
+(The literal arrow is stable enough — `useBlockRecorder` mirrors it via `useLatest`, so identity churn is harmless.)
+
+- [ ] **Step 6: Full unit suite green; commit**
+
+```bash
+git add src/services/MediaRecorderService.ts src/services/MediaRecorderService.test.ts src/hooks/useBlockRecorder.ts src/hooks/useSessionRecorder.ts src/machines/SessionRecorderMachine.ts src/machines/SessionRecorderMachine.test.ts
+git commit -m "fix: mid-block recorder death is observed, salvaged, and recovered (M1)
+
+onerror/onstop attach at start() instead of only inside stop(), feeding
+a recorderFailed input through the hooks into the machine: best-effort
+salvage, automatic restart, and a 3-strike park instead of hot-looping.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: H4 — camera switches stop, save, and resume recording
+
+**Files:**
+- Modify: `src/hooks/useSessionRecorder.ts:216-249` (readiness polling becomes bidirectional + srcObject watch)
+- Modify: `src/hooks/useSessionRecorder.test.ts` (new test)
+
+**Interfaces:** none new — `videoRef.current.srcObject` identity is the change signal; no new props.
+
+**Context — the bug:** the poll stops permanently once ready ("prevent memory leak") and `machine.videoNotReady()` has zero callers, so switching cameras mid-recording leaves the old cloned tracks live (camera LED on, old device recorded up to 5 min).
+
+- [ ] **Step 1: Failing test** — in `useSessionRecorder.test.ts`, using its `createMockTimerService` (`_triggerAllIntervals`) and mock-stream helpers:
+
+```typescript
+	it("stops and saves the current block when the video stream changes (H4)", async () => {
+		// Render enabled with ready video + stream A per existing patterns; wait for isRecording.
+		// Then swap the video element's srcObject to a new MockMediaStream instance:
+		videoElement.srcObject = new MediaStream() as unknown as MediaStream;
+		// Drive the poll:
+		act(() => {
+			timerService._triggerAllIntervals();
+		});
+		// The machine must have been told the video went away: the in-flight
+		// block stops and saves (saveSessionWithBlob called), and once the next
+		// poll tick sees the new stream ready, recording resumes.
+		await waitFor(() =>
+			expect(sessionStorage.saveSessionWithBlob).toHaveBeenCalledTimes(1),
+		);
+		act(() => {
+			timerService._triggerAllIntervals();
+		});
+		await waitFor(() => expect(result.current.isRecording).toBe(true));
+	});
+```
+
+Write it concretely against the file's existing enabled-recording setup helper (the file has tests that reach `isRecording === true`; reuse their arrangement verbatim).
+
+- [ ] **Step 2: Run — expect FAIL** (`saveSessionWithBlob` never called on stream swap)
+
+- [ ] **Step 3: Implement** — replace the whole readiness effect (lines 216-249):
+
+```typescript
+	// Video readiness + stream-change detection (bidirectional, H4).
+	// The interval runs for the hook's lifetime: readiness can be lost (device
+	// unplugged) and srcObject can be swapped (camera/resolution switch).
+	const lastSrcObjectRef = useRef<MediaStream | null>(null);
+	useEffect(() => {
+		const check = () => {
+			const video = videoRef.current;
+			const isReady = !!video && video.readyState >= 3;
+			const srcObject = (video?.srcObject as MediaStream | null) ?? null;
+
+			const streamChanged =
+				lastSrcObjectRef.current !== null &&
+				srcObject !== lastSrcObjectRef.current;
+			lastSrcObjectRef.current = srcObject;
+
+			if (streamChanged) {
+				// Stop + save the in-flight block; the old clone's tracks are
+				// released. The next tick reports the new stream's readiness and
+				// the machine resumes on its own.
+				machineRef.current?.videoNotReady();
+				return;
+			}
+			if (isReady) {
+				machineRef.current?.videoIsReady();
+			} else {
+				machineRef.current?.videoNotReady();
+			}
+		};
+
+		check();
+		const intervalId = timerService.setInterval(check, 250);
+		return () => {
+			timerService.clearInterval(intervalId);
+		};
+	}, [videoRef, timerService]);
+```
+
+Delete `videoReadyIntervalRef` (line ~82) — it has no remaining use. `videoIsReady()`/`videoNotReady()` early-return when the flag already matches, so the steady-state tick is two cheap no-ops.
+
+- [ ] **Step 4: Run the file's suite — all PASS** (the old "stops polling once ready" behavior has no dedicated test asserting the interval was cleared; if one exists and fails, rewrite it to assert the new contract — polling continues — and say so in the report)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useSessionRecorder.ts src/hooks/useSessionRecorder.test.ts
+git commit -m "fix: camera switch mid-recording stops, saves, and resumes (H4)
+
+Readiness polling becomes bidirectional and watches srcObject identity,
+so machine.videoNotReady finally has its caller: the old block is saved,
+the old clone's tracks are released (camera LED off), and recording
+re-clones the new stream when it reports ready.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Honest REC indicator
+
+**Files:**
+- Modify: `src/machines/SessionRecorderMachine.ts` (+ test): `getNotRecordingReason()`
+- Modify: `src/hooks/useSessionRecorder.ts`: expose `notRecordingReason`
+- Modify: `src/components/CameraStage.tsx:481-501`: status bar
+- Modify: `tests/magic-monitor.spec.ts`: one E2E assertion
+
+**Interfaces:**
+- Machine: `export type NotRecordingReason = "storage-error" | "recorder-error" | "starting";` and `getNotRecordingReason(): NotRecordingReason | null` (null = recording, or intentionally disabled).
+- `SessionRecorderControls` gains `notRecordingReason: NotRecordingReason | null`.
+
+- [ ] **Step 1: Failing machine tests**
+
+```typescript
+	describe("getNotRecordingReason", () => {
+		it("is null while recording and null while disabled", () => {
+			expect(machine.getNotRecordingReason()).toBeNull(); // disabled
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+			expect(machine.getNotRecordingReason()).toBeNull(); // recording
+		});
+
+		it("reports starting during benign transitions", () => {
+			machine.enable();
+			expect(machine.getNotRecordingReason()).toBe("starting");
+		});
+
+		it("reports storage-error on init failure and repeated save failures", async () => {
+			machine.enable();
+			machine.storageInitFailed();
+			expect(machine.getNotRecordingReason()).toBe("storage-error");
+		});
+
+		it("reports recorder-error after the 3-strike park", async () => {
+			machine.enable();
+			machine.storageInitialized();
+			machine.videoIsReady();
+			await machine.recorderFailed(null);
+			await machine.recorderFailed(null);
+			await machine.recorderFailed(null);
+			expect(machine.getNotRecordingReason()).toBe("recorder-error");
+		});
+	});
+```
+
+- [ ] **Step 2: Implement machine accessor**
+
+```typescript
+export type NotRecordingReason = "storage-error" | "recorder-error" | "starting";
+```
+
+```typescript
+	/**
+	 * Why recording is not running, from the machine's own point of view.
+	 * null while recording, and null while intentionally disabled (pausing is
+	 * the caller's concept, not the machine's).
+	 */
+	getNotRecordingReason(): NotRecordingReason | null {
+		if (this.state.type === "recording") return null;
+		if (!this.enabled) return null;
+		if (this.consecutiveRecorderFailures >= 3) return "recorder-error";
+		if (!this.storageReady || this.consecutiveSaveFailures >= 2) {
+			return "storage-error";
+		}
+		return "starting";
+	}
+```
+
+- [ ] **Step 3: Expose through the hook** — in `useSessionRecorder.ts`:
+
+```typescript
+	const [notRecordingReason, setNotRecordingReason] =
+		useState<NotRecordingReason | null>(null);
+```
+
+In the machine-construction effect's `onStateChange` callback, after `setIsRecording(...)`:
+
+```typescript
+					setNotRecordingReason(
+						machineRef.current?.getNotRecordingReason() ?? null,
+					);
+```
+
+(Note `machineRef.current` is assigned synchronously right after the constructor returns and no state event fires during construction, so the first invocation sees a non-null ref. Also refresh the reason in the enable/disable effect after calling `enable()`/`disable()`, since `enable()` doesn't always change state:)
+
+```typescript
+	useEffect(() => {
+		if (enabled) {
+			machineRef.current?.enable();
+		} else {
+			machineRef.current?.disable();
+		}
+		setNotRecordingReason(machineRef.current?.getNotRecordingReason() ?? null);
+	}, [enabled]);
+```
+
+Add `notRecordingReason` to `SessionRecorderControls` and the return object. Import the `NotRecordingReason` type.
+
+- [ ] **Step 4: Status bar** — replace `CameraStage.tsx` lines 491-499's inner span content with:
+
+```tsx
+				<span>
+					{isRecordingPaused ? (
+						<span className="text-yellow-400 mr-2">⏸ PAUSED</span>
+					) : sessionRecorder.isRecording ? (
+						<span className="text-red-400 mr-2">● REC</span>
+					) : sessionRecorder.notRecordingReason === "starting" ? (
+						<span className="text-gray-400 mr-2">◌ starting…</span>
+					) : sessionRecorder.notRecordingReason ? (
+						<span className="text-amber-400 font-bold text-sm mr-2">
+							⚠ NOT RECORDING (
+							{sessionRecorder.notRecordingReason === "storage-error"
+								? "storage failing"
+								: "recorder failing"}
+							)
+						</span>
+					) : null}
+					{Math.floor(sessionRecorder.currentBlockDuration)}s |{" "}
+					{sessionRecorder.recentSessions.length + sessionRecorder.savedSessions.length} sessions
+				</span>
+```
+
+- [ ] **Step 5: E2E honesty assertion** — in `tests/magic-monitor.spec.ts`, extend the Task-3-of-PR1 recording test ("Recording: Shows recording indicator when live") with a final assertion that the amber state is absent while recording:
+
+```typescript
+		await expect(page.getByText("NOT RECORDING")).toBeHidden();
+```
+
+- [ ] **Step 6: Full unit suite + the recording E2E test green; commit**
+
+Run: `nice -n 19 ionice -c 3 npx vitest run` and `nice -n 19 ionice -c 3 npx playwright test --project=chromium --workers=2 tests/magic-monitor.spec.ts -g "Recording:"`
+
+```bash
+git add src/machines/SessionRecorderMachine.ts src/machines/SessionRecorderMachine.test.ts src/hooks/useSessionRecorder.ts src/components/CameraStage.tsx tests/magic-monitor.spec.ts
+git commit -m "feat: honest REC indicator - live-but-not-recording is visible
+
+The machine exposes why it isn't recording (starting / storage-error /
+recorder-error); the status bar renders a prominent amber NOT RECORDING
+state instead of silently showing nothing.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Delete the dead playback trio (refactor commit)
+
+**Files:**
+- Modify: `src/services/MediaRecorderService.ts:164-197` (delete `createPlaybackElement`, `loadBlob`, `revokeObjectUrl`)
+- Modify: `src/services/MediaRecorderService.test.ts` (delete their describe blocks, ~lines 425-486)
+- Modify: `src/hooks/useBlockRecorder.test.ts:34-36`, `src/hooks/useRecorderDebugInfo.test.ts:34-36`, `src/hooks/useSessionRecorder.test.ts:52-54` (drop the three mock keys)
+
+**Context:** verified dead — no production caller anywhere in `src/`; `useReplayPlayer` calls `URL.createObjectURL` directly. Only their own unit tests and mock literals reference them.
+
+- [ ] **Step 1: Delete the three methods, their tests, and the mock keys** (all locations above).
+- [ ] **Step 2: Verify:** `npx tsc -b` clean, `nice -n 19 ionice -c 3 npx vitest run` all pass, and `grep -rn "createPlaybackElement\|loadBlob\|revokeObjectUrl" src/` returns nothing.
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/MediaRecorderService.ts src/services/MediaRecorderService.test.ts src/hooks/useBlockRecorder.test.ts src/hooks/useRecorderDebugInfo.test.ts src/hooks/useSessionRecorder.test.ts
+git commit -m "refactor: delete dead playback trio from MediaRecorderService
+
+createPlaybackElement/loadBlob/revokeObjectUrl have no production
+callers - useReplayPlayer manages blob URLs directly.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Full verification + PR
+
+- [ ] **Step 1:** `npx tsc -b` clean.
+- [ ] **Step 2:** `nice -n 19 ionice -c 3 npx vitest run` — all pass, output pristine.
+- [ ] **Step 3:** `nice -n 19 ionice -c 3 npx playwright test --project=chromium --workers=2` — all pass, including the PR1 keystone and recording tests against the NEW machine behavior.
+- [ ] **Step 4:** Commit this plan doc; push; open PR:
+
+```bash
+git add docs/superpowers/plans/2026-07-20-reliability-pr2-recorder-machine.md
+git commit -m "docs: PR2 recorder-machine implementation plan
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin pr/reliability-recorder
+gh pr create --title "fix: recorder machine hardening - no silent recording death (reliability sweep PR2)" --body "PR2 of 4 from the reliability sweep design (docs/superpowers/specs/2026-07-20-reliability-sweep-design.md).
+
+- H2: stopCurrentBlock re-runs the transition ladder - stop-and-view and pause/resume races can no longer park recording in a dead state (rewrites the unit test that codified the bug as intended behavior)
+- H3: generation token in useBlockRecorder - a stale stop can't clobber a newer block's recorder/stream
+- M1: MediaRecorder onerror/onstop attach at start; mid-block death salvages, restarts, 3-strike park
+- M8: save failures are counted and survivable; only genuine init failure halts recording
+- H4 (moved here from PR3's table - all touched files are PR2 files): bidirectional readiness polling + srcObject watch; camera switch stops/saves/resumes and releases the old clone
+- Honest REC: prominent amber NOT RECORDING (reason) state when live but not recording
+- Refactors in separate commits: useLatest helper; dead playback trio deleted
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Report any `test.fixme`/deviation discovered en route in the PR body.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		["html", { outputFolder: "playwright-report" }],
 	],
 	use: {
-		baseURL: "https://localhost:5173",
+		baseURL: "https://localhost:5273",
 		trace: "retain-on-failure",
 		video: "retain-on-failure",
 		screenshot: "only-on-failure",
@@ -29,8 +29,8 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: "npm run dev -- --port 5173",
-		url: "https://localhost:5173",
+		command: "npx vite --port 5273 --strictPort",
+		url: "https://localhost:5273",
 		reuseExistingServer: !process.env.CI, // Reuse existing server in dev, start fresh in CI
 		timeout: 120 * 1000,
 		stdout: "ignore",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
 	// tracked in the reliability sweep) can kill an arbitrary test under suite
 	// timing pressure; retried passes surface as "flaky", not silent green.
 	retries: process.env.CI ? 2 : 1,
-	workers: process.env.CI ? 1 : 2,
+	// Serial everywhere: several tests are timing-sensitive and flake under
+	// parallel load (a different set each run); CI was already serial.
+	workers: 1,
 	reporter: [
 		["list"],
 		["html", { outputFolder: "playwright-report", open: "never" }],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
 	testDir: "./tests",
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
+	// 1 local retry: a known app bug (MediaPipe crash on 0x0 pre-metadata frame,
+	// tracked in the reliability sweep) can kill an arbitrary test under suite
+	// timing pressure; retried passes surface as "flaky", not silent green.
+	retries: process.env.CI ? 2 : 1,
 	workers: process.env.CI ? 1 : 2,
 	reporter: [
 		["list"],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 	workers: process.env.CI ? 1 : 2,
 	reporter: [
 		["list"],
-		["html", { outputFolder: "playwright-report" }],
+		["html", { outputFolder: "playwright-report", open: "never" }],
 	],
 	use: {
 		baseURL: "https://localhost:5273",

--- a/tests/dropdown-bug.spec.ts
+++ b/tests/dropdown-bug.spec.ts
@@ -84,7 +84,11 @@ test.describe("Dropdown Bug Investigation", () => {
 		expect(value).toBe("1080p");
 	});
 
-	test("Camera source dropdown should stay open when clicked", async ({ page }) => {
+	// APP BUG: useSmartZoom runs detect() before loadedmetadata; a 0x0 frame crashes
+	// MediaPipe WASM (RET_CHECK roi->width > 0) and the error boundary tears down the
+	// UI. Passes in isolation, fails under suite timing. Fix tracked in reliability
+	// sweep (smart-zoom cluster).
+	test.fixme("Camera source dropdown should stay open when clicked", async ({ page }) => {
 		// Open settings
 		await page.getByTitle("Settings").click();
 		await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();

--- a/tests/magic-monitor.spec.ts
+++ b/tests/magic-monitor.spec.ts
@@ -562,6 +562,24 @@ test.describe("Magic Monitor E2E", () => {
 		}).toPass({ timeout: 5000 });
 	});
 
+	test("Recording: A real recorded block appears in Sessions without seeding", async ({ page }) => {
+		// Wait for recording to actually start
+		await expect(page.getByTestId("main-video")).toBeVisible();
+		await expect(page.getByText("● REC")).toBeVisible({ timeout: 10000 });
+
+		// Let the mock recorder emit at least two 1s chunks
+		await page.waitForTimeout(2500);
+
+		// Opening the picker stops and saves the current block
+		await page.getByRole("button", { name: "Sessions" }).click();
+		await expect(page.getByRole("heading", { name: "Sessions" })).toBeVisible();
+
+		// The just-recorded block must appear as a Recent session.
+		// This is the only test covering record→storage→picker for real;
+		// everything else seeds IndexedDB directly.
+		await expect(page.getByText("No recent recordings")).toBeHidden({ timeout: 10000 });
+	});
+
 	test("Settings: Resolution selector shows options", async ({ page }) => {
 		// Open settings
 		await page.getByTitle("Settings").click();

--- a/tests/magic-monitor.spec.ts
+++ b/tests/magic-monitor.spec.ts
@@ -105,7 +105,6 @@ async function injectMockCamera(page: Page) {
 		};
 
 		// Mock MediaRecorder to work with canvas streams in headless Chrome
-		const OriginalMediaRecorder = window.MediaRecorder;
 		const mockRecordings = new Map<MediaRecorder, Blob[]>();
 
 		class MockMediaRecorder {
@@ -178,18 +177,11 @@ async function injectMockCamera(page: Page) {
 			}
 		}
 
-		// Only use mock if original doesn't work with our stream
-		// Test if the original MediaRecorder works
-		try {
-			const testRecorder = new OriginalMediaRecorder(stream, { mimeType: "video/webm" });
-			testRecorder.start();
-			testRecorder.stop();
-			console.log("Original MediaRecorder works with canvas stream");
-		} catch {
-			console.log("Original MediaRecorder failed, using mock");
-			// @ts-expect-error - overriding MediaRecorder
-			window.MediaRecorder = MockMediaRecorder;
-		}
+		// Always install the mock: MediaRecorder with canvas streams is
+		// unreliable in headless Chrome, and deterministic recording data
+		// is what the recording tests depend on.
+		// @ts-expect-error - overriding MediaRecorder
+		window.MediaRecorder = MockMediaRecorder;
 	});
 }
 

--- a/tests/magic-monitor.spec.ts
+++ b/tests/magic-monitor.spec.ts
@@ -401,7 +401,10 @@ test.describe("Magic Monitor E2E", () => {
 		await page.locator("button", { hasText: "✕" }).click();
 	});
 
-	test("Sessions: Replay play/pause controls work", async ({ page }) => {
+	// APP BUG: useReplayPlayer StrictMode mount/unmount race can leave video.src empty
+	// -> MEDIA_ERR_SRC_NOT_SUPPORTED. Fixture verified good. Fix tracked in reliability
+	// sweep (replay cluster).
+	test.fixme("Sessions: Replay play/pause controls work", async ({ page }) => {
 		// Seed with sessions
 		await seedSessionBuffer(page, 1);
 		await page.reload();
@@ -589,9 +592,11 @@ test.describe("Magic Monitor E2E", () => {
 		await expect(resolutionSelect).toBeVisible();
 
 		// Verify all resolution options are present
-		await expect(resolutionSelect).toContainText("720p (HD)");
-		await expect(resolutionSelect).toContainText("1080p (Full HD)");
-		await expect(resolutionSelect).toContainText("4K (Ultra HD)");
+		// Labels show requested width, not the preset label (see commit 856da46:
+		// only width is constrained so the camera can pick its native aspect ratio)
+		await expect(resolutionSelect).toContainText("1280 wide (720p)");
+		await expect(resolutionSelect).toContainText("1920 wide (1080p)");
+		await expect(resolutionSelect).toContainText("3840 wide (4k)");
 	});
 
 	test("Settings: Resolution selector defaults to 4K", async ({ page }) => {

--- a/tests/magic-monitor.spec.ts
+++ b/tests/magic-monitor.spec.ts
@@ -533,38 +533,33 @@ test.describe("Magic Monitor E2E", () => {
 		await expect(video).toBeVisible();
 	});
 
-	// Skip recording tests - MediaRecorder with canvas stream doesn't work reliably in headless Chrome
-	// These would need either a real video file or more sophisticated mocking
-	test.skip("Recording: Shows recording indicator when live", async ({ page }) => {
+	test("Recording: Shows recording indicator when live", async ({ page }) => {
 		// Wait for app to load and start recording
 		const video = page.getByTestId("main-video");
 		await expect(video).toBeVisible();
 
-		// Recording indicator should show "REC" or recording duration
-		// Look for the recording indicator in the control bar
-		const recordingIndicator = page.locator("text=/REC|\\d+:\\d+/");
-		await expect(recordingIndicator.first()).toBeVisible({ timeout: 10000 });
+		// Recording indicator should show REC once video + storage are ready
+		const recordingIndicator = page.getByText("● REC");
+		await expect(recordingIndicator).toBeVisible({ timeout: 10000 });
 	});
 
-	test.skip("Recording: Duration counter increases over time", async ({ page }) => {
+	test("Recording: Duration counter increases over time", async ({ page }) => {
 		// Wait for app to load
 		const video = page.getByTestId("main-video");
 		await expect(video).toBeVisible();
 
-		// Wait for recording to start (should show a duration like "0:01" or "0:00")
-		const durationRegex = /\d+:\d{2}/;
-		await expect(page.getByText(durationRegex).first()).toBeVisible({ timeout: 10000 });
+		// Status bar shows "<seconds>s | <n> sessions" while live
+		// (.first() — the regex also matches ancestor spans; match innermost deterministically)
+		const statusReadout = page.getByText(/\d+s \|/).first();
+		await expect(statusReadout).toBeVisible({ timeout: 10000 });
 
-		// Get initial duration text
-		const durationElement = page.getByText(durationRegex).first();
-		const initialText = await durationElement.textContent();
+		const initialText = await statusReadout.textContent();
 
-		// Wait 2 seconds for counter to increase
-		await page.waitForTimeout(2000);
-
-		// Duration should have increased
-		const newText = await durationElement.textContent();
-		expect(newText).not.toBe(initialText);
+		// Wait for the block duration to tick up
+		await expect(async () => {
+			const newText = await statusReadout.textContent();
+			expect(newText).not.toBe(initialText);
+		}).toPass({ timeout: 5000 });
 	});
 
 	test("Settings: Resolution selector shows options", async ({ page }) => {

--- a/tests/session-recorder.spec.ts
+++ b/tests/session-recorder.spec.ts
@@ -273,7 +273,7 @@ test.describe("Session Recorder with Counter Video", () => {
 		await expect(page.getByText("REPLAY MODE")).toBeHidden({ timeout: 5000 });
 	});
 
-	test("Replay controls can be floated and dragged", async ({ page }) => {
+	test("Replay controls are draggable", async ({ page }) => {
 		// Navigate first, then seed sessions
 		await page.goto("/");
 		await seedSessionBuffer(page, 1);
@@ -292,23 +292,31 @@ test.describe("Session Recorder with Counter Video", () => {
 		await timelineThumbs.first().click();
 		await expect(page.getByText("REPLAY MODE")).toBeVisible();
 
-		// Find the float button
-		const floatButton = page.getByLabel("Float controls");
-		await expect(floatButton).toBeVisible();
-
-		// Click to float
-		await floatButton.click();
-
-		// Now should show dock button
-		await expect(page.getByLabel("Dock controls")).toBeVisible();
-
-		// The control panel should now have a drag handle
-		const dragHandle = page.locator(".w-12.h-1.bg-gray-600.rounded-full");
+		// Controls are always docked (float/dock toggle was removed, eb54b7f) but
+		// remain draggable via the grip handle
+		const dragHandle = page.getByTitle("Drag to move");
 		await expect(dragHandle).toBeVisible();
 
-		// Click dock to return to normal
-		await page.getByLabel("Dock controls").click();
-		await expect(page.getByLabel("Float controls")).toBeVisible();
+		const startBox = await dragHandle.boundingBox();
+		expect(startBox).toBeTruthy();
+		if (!startBox) return;
+
+		const startX = startBox.x + startBox.width / 2;
+		const startY = startBox.y + startBox.height / 2;
+
+		// Drag the panel by (40, 30)
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+		await page.mouse.move(startX + 40, startY + 30, { steps: 5 });
+		await page.mouse.up();
+
+		const endBox = await dragHandle.boundingBox();
+		expect(endBox).toBeTruthy();
+		if (!endBox) return;
+
+		// Panel should have moved from its original position
+		expect(endBox.x).not.toBe(startBox.x);
+		expect(endBox.y).not.toBe(startBox.y);
 
 		// Exit replay
 		await page.locator("button", { hasText: "✕" }).click();
@@ -428,8 +436,10 @@ test.describe("Session Recorder with Counter Video", () => {
 		const timelineTrack = page.locator(".bg-gray-700.rounded-full").first();
 		await expect(timelineTrack).toBeVisible();
 
-		// Get the time display to monitor position changes
-		const timeDisplay = page.locator(".font-mono").first();
+		// Get the time display to monitor position changes.
+		// `.font-mono` alone is ambiguous (also matches the empty status-bar div and
+		// the "REPLAY MODE" banner), so scope to the element with the actual time text.
+		const timeDisplay = page.locator(".font-mono", { hasText: /^\d+:\d{2}\.\d/ });
 		await expect(timeDisplay).toBeVisible();
 
 		// Get initial time

--- a/tests/session-recorder.spec.ts
+++ b/tests/session-recorder.spec.ts
@@ -61,7 +61,7 @@ async function injectCounterCamera(page: Page) {
 		draw();
 
 		// Expose counter for test verification
-		(window as Window & { counterCamera: { getCounter: () => number; reset: () => void } }).counterCamera = {
+		(window as unknown as Window & { counterCamera: { getCounter: () => number; reset: () => void } }).counterCamera = {
 			getCounter: () => counter,
 			reset: () => {
 				startTime = Date.now();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"files": [],
 	"references": [
 		{ "path": "./tsconfig.app.json" },
-		{ "path": "./tsconfig.node.json" }
+		{ "path": "./tsconfig.node.json" },
+		{ "path": "./tsconfig.test.json" }
 	]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.node.json",
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+		"lib": ["ES2023", "DOM", "DOM.Iterable"]
+	},
+	"include": ["tests"]
+}


### PR DESCRIPTION
PR1 of 4 from the reliability sweep design (spec: PR #66, `docs/superpowers/specs/2026-07-20-reliability-sweep-design.md`). **Test infrastructure only — zero `src/` changes.**

## What this fixes

- **The E2E MediaRecorder mock was silently broken**: its "prefer the real recorder" detection referenced an undefined variable, so the try always threw and the mock was always installed. Now deterministic and intentional (`28ce2ee`).
- **Playwright could never boot its own dev server**: `npm run dev -- --port 5173` forwards `--port` into `just`, which errors — local E2E silently depended on a manually-running dev server, and **the Playwright CI workflow has been red since April**. Now `npx vite --port 5273 --strictPort` on a dedicated port that can't collide with a dev server on 5173 (`e5ccd95`).
- **`tests/` was type-checked by nothing** — exactly how the mock bug hid. Now under `tsc -b` (`3d8ca4d`).
- **Both recording E2E tests un-skipped** (obsolete skip reason; duration test rewritten to match the real `Ns | M sessions` readout) (`f95c945`).
- **Keystone test added**: record → stop → save → appears in Sessions with NO IndexedDB seeding — first-ever coverage of the real recording path; previously broken wiring would ship green (`9ee3dac`).
- **HTML reporter no longer hangs headless runs** (`open: "never"` — the on-failure report server blocked processes for 45+ min) (`6d9daeb`).

## Discovered by running the full suite locally for the first time

- **3 stale tests fixed** — UI drifted in December (`856da46` resolution labels, `eb54b7f` float/dock removal) without the E2E tests following (`a610464`).
- **2 real app bugs found**, marked `test.fixme` with evidence, fixes tracked for later sweep PRs (`a610464`):
  - MediaPipe crashes on a 0×0 pre-metadata frame in `useSmartZoom` and the error boundary tears down the whole UI (wanders between tests under load)
  - `useReplayPlayer` StrictMode blob-URL race → `MEDIA_ERR_SRC_NOT_SUPPORTED`
- **Timing-sensitive tests flake under parallel workers** (different set each run; all pass serially): `workers: 1` everywhere (CI already was) + 1 local retry so survivors report as *flaky*, never silent (`eadfe94`, `1256f0e`).

## Verification

Full serial E2E: **24 passed / 2 flaky (pass on retry, both known classes) / 3 skipped / 0 failed**, 6.1m. Unit: 568 passed. `tsc -b` clean. Final whole-branch review: READY TO MERGE, no Critical/Important findings.

Plans for this PR and PR2 (recorder machine) are included under `docs/superpowers/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)